### PR TITLE
:sparkles: add 5 mins cache servers ouptut canvas content

### DIFF
--- a/src/commands/servers/canvas/serversCanvas.ts
+++ b/src/commands/servers/canvas/serversCanvas.ts
@@ -1,5 +1,5 @@
 import { createCanvas, Canvas2DContext } from '../../../services/canvasBackend';
-import { OnlineServerItem } from '../types/types';
+import { HistoricalServerItem, OnlineServerItem } from '../types/types';
 import {
     getServersHeaderDisplaySectionText,
     calcCanvasTextWidth,
@@ -8,8 +8,12 @@ import {
 } from '../utils/utils';
 import { BaseCanvas } from '../../../services/baseCanvas';
 
+const HISTORY_LINE_HEIGHT = 30;
+const HISTORY_SECTION_TITLE = '近5分钟离线服务器';
+
 export class ServersCanvas extends BaseCanvas {
     serverList: OnlineServerItem[];
+    historicalServers: HistoricalServerItem[];
     fileName: string;
 
     measureMaxWidth = 0;
@@ -30,9 +34,14 @@ export class ServersCanvas extends BaseCanvas {
 
     totalFooter = '';
 
-    constructor(serverList: OnlineServerItem[], fileName: string) {
+    constructor(
+        serverList: OnlineServerItem[],
+        historicalServers: HistoricalServerItem[],
+        fileName: string,
+    ) {
         super();
         this.serverList = serverList;
+        this.historicalServers = historicalServers;
         this.fileName = fileName;
     }
 
@@ -63,7 +72,24 @@ export class ServersCanvas extends BaseCanvas {
             }
         });
 
-        this.renderHeight = 120 + this.serverList.length * 40;
+        let historicalHeight = 0;
+        if (this.historicalServers.length > 0) {
+            historicalHeight =
+                40 + HISTORY_LINE_HEIGHT * this.historicalServers.length + 10;
+            this.historicalServers.forEach((s) => {
+                const sectionData = getServerInfoDisplaySectionText(s);
+                const outputText =
+                    sectionData.serverSection +
+                    sectionData.playersSection +
+                    sectionData.mapSection;
+                if (outputText.length > this.maxLengthStr.length) {
+                    this.maxLengthStr = outputText;
+                }
+            });
+        }
+
+        this.renderHeight =
+            120 + this.serverList.length * 40 + historicalHeight;
     }
 
     renderLayout(context: Canvas2DContext, width: number, height: number) {
@@ -157,6 +183,70 @@ export class ServersCanvas extends BaseCanvas {
         });
     }
 
+    renderHistoricalList(context: Canvas2DContext) {
+        if (this.historicalServers.length === 0) {
+            return;
+        }
+
+        this.renderStartY += 15;
+
+        context.font = 'bold 14pt Consolas';
+        context.textAlign = 'left';
+        context.textBaseline = 'top';
+        context.fillStyle = '#9ca3af';
+        context.fillText(HISTORY_SECTION_TITLE, 20, 10 + this.renderStartY);
+
+        this.renderStartY += 40;
+
+        context.font = '16pt Consolas';
+
+        this.historicalServers.forEach((s) => {
+            const sectionData = getServerInfoDisplaySectionText(s);
+
+            context.fillStyle = '#6b7280';
+            context.fillText(
+                sectionData.serverSection,
+                20,
+                10 + this.renderStartY,
+            );
+            const serverSectionWidth = context.measureText(
+                sectionData.serverSection,
+            ).width;
+
+            context.fillStyle = '#9ca3af';
+            context.fillText(
+                sectionData.playersSection,
+                20 + serverSectionWidth,
+                10 + this.renderStartY,
+            );
+            const playersSectionWidth = context.measureText(
+                sectionData.playersSection,
+            ).width;
+
+            context.fillStyle = '#6b7280';
+            context.fillText(
+                sectionData.mapSection,
+                20 + serverSectionWidth + playersSectionWidth,
+                10 + this.renderStartY,
+            );
+            const mapSectionWidth = context.measureText(
+                sectionData.mapSection,
+            ).width;
+
+            const elapsedMin = Math.ceil((Date.now() - s.lastSeenAt) / 60000);
+            context.fillStyle = '#9ca3af';
+            context.font = '12pt Consolas';
+            context.fillText(
+                `${elapsedMin}分钟前`,
+                20 + serverSectionWidth + playersSectionWidth + mapSectionWidth,
+                10 + this.renderStartY,
+            );
+
+            context.font = '16pt Consolas';
+            this.renderStartY += HISTORY_LINE_HEIGHT;
+        });
+    }
+
     renderRect(context: Canvas2DContext) {
         context.strokeStyle = '#f48225';
         context.rect(
@@ -180,6 +270,7 @@ export class ServersCanvas extends BaseCanvas {
         const titleWidth = context.measureText(this.totalTitle).width + 30;
         this.renderList(context);
         const listWidth = this.maxRectWidth + 40;
+        this.renderHistoricalList(context);
         this.renderFooter(context);
         const footerWidth = context.measureText(this.totalFooter).width + 30;
 
@@ -198,6 +289,7 @@ export class ServersCanvas extends BaseCanvas {
         this.renderTitle(context);
         this.renderRect(context);
         this.renderList(context);
+        this.renderHistoricalList(context);
         this.renderFooter(context);
 
         return super.writeFile(canvas, this.fileName);

--- a/src/commands/servers/register.ts
+++ b/src/commands/servers/register.ts
@@ -29,6 +29,7 @@ import {
     serverCommandCache,
     ApiResult,
 } from '../../services/serverCommandCache.service';
+import { serverHistoryCache } from '../../services/serverHistoryCache.service';
 
 // ============================================================================
 // 简化的命令工厂函数
@@ -181,7 +182,13 @@ export const ServersCommandRegister = createServerCommand(
                 const serverList = await queryAllServers(
                     ctx.env.SERVERS_MATCH_REGEX,
                 );
-                printServerListPng(serverList, SERVERS_OUTPUT_FILE);
+                const historicalServers =
+                    serverHistoryCache.getDisappearedServers(serverList);
+                printServerListPng(
+                    serverList,
+                    historicalServers,
+                    SERVERS_OUTPUT_FILE,
+                );
                 return { serverList, outputFile: SERVERS_OUTPUT_FILE };
             },
             buildReply: async (apiResult) =>

--- a/src/commands/servers/tasks/analyticsServerTask.ts
+++ b/src/commands/servers/tasks/analyticsServerTask.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { CronJob } from 'cron';
 import { GlobalEnv } from '../../../types';
 import { queryAllServers } from '../utils/utils';
+import { serverHistoryCache } from '../../../services/serverHistoryCache.service';
 import { logger } from '../../../utils/logger';
 import {
     IServerAnalyticsRecord,
@@ -114,6 +115,7 @@ export class AnalysticsServerTask {
         AnalysticsServerTask.isUpdating = true;
         try {
             const serverList = await queryAllServers(env.SERVERS_MATCH_REGEX);
+            serverHistoryCache.updateSnapshot(serverList);
             const date = new Date();
             const dateStr = `${date.getHours()}时`;
 

--- a/src/commands/servers/types/types.ts
+++ b/src/commands/servers/types/types.ts
@@ -55,6 +55,10 @@ export interface IServerAnalyticsHourlyData {
     count: number;
 }
 
+export interface HistoricalServerItem extends OnlineServerItem {
+    lastSeenAt: number;
+}
+
 export interface IServerAnalyticsRecord {
     serverKey: string;
     serverName: string;

--- a/src/commands/servers/utils/canvas.test.ts
+++ b/src/commands/servers/utils/canvas.test.ts
@@ -79,7 +79,7 @@ afterEach(() => {
 describe('servers canvas print utilities', () => {
     it('prints server list png', () => {
         const fileName = 'servers-test.png';
-        const outputPath = printServerListPng(servers, fileName);
+        const outputPath = printServerListPng(servers, [], fileName);
         expect(outputPath.endsWith(path.join('out', fileName))).toBe(true);
         expect(fs.existsSync(outputPath)).toBe(true);
     });

--- a/src/commands/servers/utils/canvas.ts
+++ b/src/commands/servers/utils/canvas.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import {
+    HistoricalServerItem,
     IMapDataItem,
     IUserMatchedServerItem,
     OnlineServerItem,
@@ -18,13 +19,18 @@ const OUTPUT_FOLDER = 'out';
  */
 export const printServerListPng = (
     serverList: OnlineServerItem[],
-    fileName: string
+    historicalServers: HistoricalServerItem[],
+    fileName: string,
 ) => {
     if (!fs.existsSync(OUTPUT_FOLDER)) {
         fs.mkdirSync(OUTPUT_FOLDER);
     }
 
-    const outputPath = new ServersCanvas(serverList, fileName).render();
+    const outputPath = new ServersCanvas(
+        serverList,
+        historicalServers,
+        fileName,
+    ).render();
 
     return outputPath;
 };
@@ -36,7 +42,7 @@ export const printServerListPng = (
  */
 export const printPlayersPng = (
     serverList: OnlineServerItem[],
-    fileName: string
+    fileName: string,
 ): string => {
     if (!fs.existsSync(OUTPUT_FOLDER)) {
         fs.mkdirSync(OUTPUT_FOLDER);
@@ -58,7 +64,7 @@ export const printUserInServerListPng = (
     matchList: IUserMatchedServerItem[],
     query: string,
     count: number,
-    fileName: string
+    fileName: string,
 ): string => {
     if (!fs.existsSync(OUTPUT_FOLDER)) {
         fs.mkdirSync(OUTPUT_FOLDER);
@@ -68,7 +74,7 @@ export const printUserInServerListPng = (
         matchList,
         query,
         count,
-        fileName
+        fileName,
     ).render();
 
     return outputPath;
@@ -77,17 +83,13 @@ export const printUserInServerListPng = (
 export const printMapPng = (
     serverList: OnlineServerItem[],
     mapData: IMapDataItem[],
-    fileName: string
+    fileName: string,
 ): string => {
     if (!fs.existsSync(OUTPUT_FOLDER)) {
         fs.mkdirSync(OUTPUT_FOLDER);
     }
 
-    const outputPath = new MapsCanvas(
-        serverList,
-        mapData,
-        fileName
-    ).render();
+    const outputPath = new MapsCanvas(serverList, mapData, fileName).render();
 
     return outputPath;
 };

--- a/src/services/serverHistoryCache.service.ts
+++ b/src/services/serverHistoryCache.service.ts
@@ -1,0 +1,83 @@
+import { logger } from '../utils/logger';
+import type {
+    OnlineServerItem,
+    HistoricalServerItem,
+} from '../commands/servers/types/types';
+
+const HISTORY_TTL_MS = 5 * 60 * 1000;
+
+interface SnapshotEntry {
+    server: OnlineServerItem;
+    lastSeenAt: number;
+}
+
+class ServerHistoryCacheService {
+    private snapshots = new Map<string, SnapshotEntry>();
+
+    private getServerKey(address: string, port: number): string {
+        return `${address}:${port}`;
+    }
+
+    updateSnapshot(currentList: OnlineServerItem[]): void {
+        const now = Date.now();
+
+        for (const server of currentList) {
+            const key = this.getServerKey(server.address, server.port);
+            const existing = this.snapshots.get(key);
+            if (existing) {
+                existing.server = server;
+                existing.lastSeenAt = now;
+            } else {
+                this.snapshots.set(key, {
+                    server,
+                    lastSeenAt: now,
+                });
+            }
+        }
+
+        this.evictExpired(now);
+    }
+
+    getDisappearedServers(
+        currentList: OnlineServerItem[],
+    ): HistoricalServerItem[] {
+        const now = Date.now();
+        const currentKeys = new Set(
+            currentList.map((s) => this.getServerKey(s.address, s.port)),
+        );
+
+        const result: HistoricalServerItem[] = [];
+
+        for (const [key, entry] of this.snapshots) {
+            if (currentKeys.has(key)) {
+                continue;
+            }
+
+            const elapsed = now - entry.lastSeenAt;
+            if (elapsed > HISTORY_TTL_MS) {
+                continue;
+            }
+
+            result.push({
+                ...entry.server,
+                lastSeenAt: entry.lastSeenAt,
+            });
+        }
+
+        return result.sort((a, b) => a.lastSeenAt - b.lastSeenAt);
+    }
+
+    private evictExpired(now: number): void {
+        for (const [key, entry] of this.snapshots) {
+            if (now - entry.lastSeenAt > HISTORY_TTL_MS) {
+                this.snapshots.delete(key);
+            }
+        }
+    }
+
+    getStats(): { snapshotCount: number } {
+        return { snapshotCount: this.snapshots.size };
+    }
+}
+
+export const serverHistoryCache = new ServerHistoryCacheService();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Recently Offline Servers" section to the server list display that shows servers that went offline within the last 5 minutes, including elapsed time since each server was last seen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->