### PR TITLE
feat(servers): add map detail query with canvas rendering and map ima…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ ecosystem.config.js
 .kilocode/
 .claude/
 .specify/
+.kilo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ out/                # Canvas image output directory (served as static /out/)
 - Loaded via `dotenv` in `src/utils/env.ts`
 - **Parsing quirks**: Values are stripped of surrounding quotes (`'` or `"`). Arrays are parsed as JSON (e.g., `ACTIVE_COMMANDS=["fuck","roll"]`)
 - `START_MATCH` is parsed specially to extract the command prefix
+- **Map image config**: `MAP_IMAGE_CONFIG_FILE` (path to `map_images.json`) is optional. When set, `MapImageService` loads a `{ images: [{ path, image }] }` config for map detail images. `MAP_IMAGE_BASE_URL` serves as fallback when no config match is found. Use `scripts/syncMapImages.js` to sync from a remote HTTP endpoint.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - TDOLL_DATA_FILE: 战术人形数据文件路径
 - TDOLL_SKIN_DATA_FILE: 战术人形皮肤数据文件路径
 - MAPS_DATA_FILE: 地图数据文件路径
+- MAP_IMAGE_CONFIG_FILE: 地图图片配置文件路径, 格式 `{ "images": [{ "path": "...", "image": "..." }] }`, 可通过 `scripts/syncMapImages.js` 从远程端点同步
+- MAP_IMAGE_BASE_URL: 地图图片兜底 URL 前缀, 无配置匹配时拼接为 `<BASE_URL><shortName>.png`
 - QA_DATA_FILE: 自助问答数据文件路径
 - DIFY_AI_URL: DIFY AI 请求 URL (包含 `/chat-messages`)
 - DIFY_AI_TOKEN: DIFY AI 请求 Token
@@ -49,7 +51,7 @@
 | servers | 服务器信息 (图片) | 否 | `#servers` |
 | whereis / w | 玩家所在服务器 | 否 | `#whereis player1` |
 | analytics / a | 服务器玩家统计 | 否 | `#analytics d` |
-| maps / m | 地图列表 | 否 | `#maps` |
+| maps / m | 地图列表/详情 | 否 | `#maps` / `#maps map105` |
 | players / p | 服务器玩家列表 | 否 | `#players` |
 | tdoll / td | 人形数据查询 | 否 | `#tdoll M4A1` |
 | tdollskin / ts | 人形皮肤查询 | 否 | `#tdollskin 3` |

--- a/scripts/syncMapImages.js
+++ b/scripts/syncMapImages.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Usage: node scripts/syncMapImages.js --remote-url <url> --output <path>
+//
+// 从远程端点拉取地图图片数据，合并/覆盖到本地 map_images.json
+// 远程返回格式: [{ name, path, image }, ...]
+// 本地输出格式: { images: [{ path, image, name? }, ...] }
+
+import fs from 'fs';
+import path from 'path';
+import https from 'node:https';
+import http from 'node:http';
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const result = {
+        remoteUrl: null,
+        outputFile: null,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === '--remote-url') {
+            result.remoteUrl = args[++i];
+        } else if (arg === '-o' || arg === '--output') {
+            result.outputFile = args[++i];
+        } else if (arg === '-h' || arg === '--help') {
+            showHelp();
+            process.exit(0);
+        }
+    }
+
+    return result;
+}
+
+function showHelp() {
+    console.log(`
+Usage: node scripts/syncMapImages.js [options]
+
+Options:
+  --remote-url <url>   远程 HTTP 端点 URL (必需)
+  -o, --output <path>  输出文件路径 (默认: ./map_images.json)
+  -h, --help           显示帮助信息
+
+Examples:
+  node scripts/syncMapImages.js --remote-url https://example.com/api/maps
+  node scripts/syncMapImages.js --remote-url https://example.com/api/maps -o data/map_images.json
+`);
+}
+
+function fetchJson(url) {
+    return new Promise((resolve, reject) => {
+        const client = url.startsWith('https') ? https : http;
+
+        client
+            .get(url, (res) => {
+                if (res.statusCode < 200 || res.statusCode >= 300) {
+                    reject(
+                        new Error(
+                            `HTTP ${res.statusCode}: ${res.statusMessage}`,
+                        ),
+                    );
+                    return;
+                }
+
+                let data = '';
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    try {
+                        resolve(JSON.parse(data));
+                    } catch (e) {
+                        reject(
+                            new Error(
+                                `Failed to parse JSON: ${e.message}`,
+                            ),
+                        );
+                    }
+                });
+            })
+            .on('error', reject);
+    });
+}
+
+async function main() {
+    const args = parseArgs();
+
+    if (!args.remoteUrl) {
+        console.error('Error: --remote-url is required');
+        showHelp();
+        process.exit(1);
+    }
+
+    const outputFile = args.outputFile || './map_images.json';
+
+    console.log(`Fetching data from: ${args.remoteUrl}`);
+    const remoteData = await fetchJson(args.remoteUrl);
+
+    if (!Array.isArray(remoteData)) {
+        console.error('Error: Remote response is not an array');
+        process.exit(1);
+    }
+
+    console.log(`Received ${remoteData.length} entries from remote`);
+
+    // Read existing local config if file exists
+    let localMap = new Map();
+    if (fs.existsSync(outputFile)) {
+        try {
+            const localRaw = fs.readFileSync(outputFile, 'utf-8');
+            const localConfig = JSON.parse(localRaw);
+            if (localConfig.images && Array.isArray(localConfig.images)) {
+                for (const item of localConfig.images) {
+                    localMap.set(item.path, item);
+                }
+            }
+            console.log(
+                `Loaded ${localMap.size} existing entries from ${outputFile}`,
+            );
+        } catch (e) {
+            console.warn(
+                `Warning: Failed to read existing config: ${e.message}`,
+            );
+        }
+    }
+
+    // Merge remote entries into local map (remote overwrites local by path)
+    for (const item of remoteData) {
+        if (!item.path) {
+            console.warn('Warning: Skipping entry without path:', item);
+            continue;
+        }
+
+        const entry = {
+            path: item.path,
+            image: item.image || '',
+        };
+        if (item.name) {
+            entry.name = item.name;
+        }
+        localMap.set(item.path, entry);
+    }
+
+    // Build output
+    const output = {
+        images: Array.from(localMap.values()),
+    };
+
+    // Ensure output directory exists
+    const outputDir = path.dirname(outputFile);
+    if (outputDir && !fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    fs.writeFileSync(outputFile, JSON.stringify(output, null, 4));
+
+    console.log(
+        `Successfully wrote ${output.images.length} entries to ${outputFile}`,
+    );
+}
+
+main().catch((err) => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+});

--- a/src/commands/servers/README.md
+++ b/src/commands/servers/README.md
@@ -54,16 +54,20 @@
 
 ### 用途
 
-根据 MAPS_DATA_FILE 提供的地图数据, 生成地图列表图片输出
+根据 MAPS_DATA_FILE 提供的地图数据, 生成地图列表图片输出。支持查询指定地图详情（服务器列表 + 地图缩略图）。
 
 ### 环境变量
 
--   MAPS_DATA_FILE: 用于提供地图数据的 JSON 数据文件名
+-   MAPS_DATA_FILE: 用于提供地图数据的 JSON 数据文件名, 格式 `[{ "id": "map105", "name": "Map Name" }]`
+-   MAP_IMAGE_CONFIG_FILE: 地图图片配置文件路径, 格式 `{ "images": [{ "path": "media/.../map105", "image": "url" }] }`, 可通过 `scripts/syncMapImages.js` 从远程端点同步生成
+-   MAP_IMAGE_BASE_URL: 无配置匹配时的兜底图片 URL 前缀, 拼接方式为 `<BASE_URL><shortName>.png`
 -   OUTPUT_BG_IMG: 将输出的图片添加背景图 layer 层, 位于底色上方
 
 ### 注册的指令
 
 -   maps: 根据 MAPS_DATA_FILE 提供的地图数据, 生成地图列表图片输出
+    -   无参数: 生成完整地图列表图片
+    -   带参数 (如 `#maps map105`): 查询指定地图详情, 输出包含服务器列表图片和地图缩略图
 -   m: maps 的别名
 
 ## players

--- a/src/commands/servers/canvas/mapDetailCanvas.ts
+++ b/src/commands/servers/canvas/mapDetailCanvas.ts
@@ -1,0 +1,176 @@
+import { createCanvas, Canvas2DContext } from '../../../services/canvasBackend';
+import { IMapDataItem, OnlineServerItem } from '../types/types';
+import {
+    calcCanvasTextWidth,
+    getCountColor,
+    getMapShortName,
+} from '../utils/utils';
+import { BaseCanvas } from '../../../services/baseCanvas';
+
+export class MapDetailCanvas extends BaseCanvas {
+    map: IMapDataItem;
+    servers: OnlineServerItem[];
+    fileName: string;
+
+    renderWidth = 0;
+    renderHeight = 0;
+
+    totalTitle = '';
+    maxRectWidth = 0;
+    contentLines = 0;
+
+    constructor(
+        map: IMapDataItem,
+        servers: OnlineServerItem[],
+        fileName: string,
+    ) {
+        super();
+        this.map = map;
+        this.servers = servers;
+        this.fileName = fileName;
+    }
+
+    measure() {
+        const title = `地图详情: ${this.map.name} (${this.map.id})`;
+        this.totalTitle = title;
+
+        const titleWidth = calcCanvasTextWidth(title, 20) + 40;
+
+        this.maxRectWidth = titleWidth;
+
+        this.contentLines = 1;
+
+        if (this.servers.length === 0) {
+            const noServerText = '当前没有服务器正在运行此地图';
+            const noServerWidth = calcCanvasTextWidth(noServerText, 16) + 40;
+            if (noServerWidth > this.maxRectWidth) {
+                this.maxRectWidth = noServerWidth;
+            }
+            this.contentLines += 1;
+        } else {
+            for (const s of this.servers) {
+                const status =
+                    s.current_players === s.max_players ? '已满' : '在线';
+                const line = `${s.name}  | ${s.current_players}/${s.max_players} 玩家 | ${status}`;
+                const lineWidth = calcCanvasTextWidth(line, 16) + 80;
+                if (lineWidth > this.maxRectWidth) {
+                    this.maxRectWidth = lineWidth;
+                }
+                this.contentLines += 1;
+            }
+        }
+
+        const summaryText = `共 ${this.servers.length} 个服务器正在运行此地图`;
+        const summaryWidth = calcCanvasTextWidth(summaryText, 16) + 40;
+        if (summaryWidth > this.maxRectWidth) {
+            this.maxRectWidth = summaryWidth;
+        }
+        this.contentLines += 1;
+
+        this.renderHeight = 80 + this.contentLines * 40 + 40;
+        this.renderWidth = this.maxRectWidth;
+    }
+
+    renderLayout(context: Canvas2DContext, width: number, height: number) {
+        context.fillStyle = '#451a03';
+        context.fillRect(0, 0, width, height);
+    }
+
+    renderTitle(context: Canvas2DContext) {
+        context.font = 'bold 20pt Consolas';
+        context.textAlign = 'left';
+        context.textBaseline = 'top';
+        context.fillStyle = '#fff';
+        context.fillText(this.totalTitle, 10, 10);
+
+        this.renderStartY = 10 + 40 + 10;
+
+        context.strokeStyle = '#f48225';
+        context.beginPath();
+        context.moveTo(10, this.renderStartY);
+        context.lineTo(this.renderWidth - 10, this.renderStartY);
+        context.stroke();
+
+        this.renderStartY += 10;
+    }
+
+    renderServerList(context: Canvas2DContext) {
+        context.font = '16pt Consolas';
+        context.textAlign = 'left';
+        context.textBaseline = 'top';
+
+        if (this.servers.length === 0) {
+            context.fillStyle = '#9ca3af';
+            context.fillText(
+                '当前没有服务器正在运行此地图',
+                20,
+                this.renderStartY,
+            );
+            this.renderStartY += 40;
+        } else {
+            for (const s of this.servers) {
+                const status =
+                    s.current_players === s.max_players ? '已满' : '在线';
+
+                context.fillStyle = '#bfdbfe';
+                context.fillText(s.name, 20, this.renderStartY);
+
+                const nameWidth = context.measureText(s.name).width;
+
+                context.fillStyle = getCountColor(
+                    s.current_players,
+                    s.max_players,
+                );
+                const playersText = `  | ${s.current_players}/${s.max_players} 玩家`;
+                context.fillText(
+                    playersText,
+                    20 + nameWidth,
+                    this.renderStartY,
+                );
+
+                const playersWidth = context.measureText(playersText).width;
+                context.fillStyle =
+                    status === '已满' ? '#ef4444' : '#22c55e';
+                context.fillText(
+                    ` | ${status}`,
+                    20 + nameWidth + playersWidth,
+                    this.renderStartY,
+                );
+
+                this.renderStartY += 40;
+            }
+        }
+
+        context.strokeStyle = '#f48225';
+        context.beginPath();
+        context.moveTo(10, this.renderStartY);
+        context.lineTo(this.renderWidth - 10, this.renderStartY);
+        context.stroke();
+        this.renderStartY += 10;
+
+        context.fillStyle = '#9ca3af';
+        context.font = '14pt Consolas';
+        context.fillText(
+            `共 ${this.servers.length} 个服务器正在运行此地图`,
+            20,
+            this.renderStartY,
+        );
+        this.renderStartY += 40;
+    }
+
+    render() {
+        this.record();
+        this.measure();
+
+        const canvas = createCanvas(this.renderWidth, this.renderHeight);
+        const context = canvas.getContext('2d');
+
+        this.renderLayout(context, this.renderWidth, this.renderHeight);
+        this.renderBgImg(context, this.renderWidth, this.renderHeight);
+        this.renderTitle(context);
+        this.renderServerList(context);
+        this.renderFooter(context);
+
+        return super.writeFile(canvas, this.fileName);
+    }
+}

--- a/src/commands/servers/register.ts
+++ b/src/commands/servers/register.ts
@@ -3,17 +3,24 @@ import { GlobalEnv, MsgExecCtx, IRegister } from '../../types';
 import { getStaticHttpPath } from '../../utils/cmdreq';
 import {
     printMapPng,
+    printMapDetailPng,
     printPlayersPng,
     printServerListPng,
     printUserInServerListPng,
 } from './utils/canvas';
 import {
     MAPS_OUTPUT_FILE,
+    MAP_DETAIL_OUTPUT_FILE,
     PLAYERS_OUTPUT_FILE,
     SERVERS_OUTPUT_FILE,
     WHEREIS_OUTPUT_FILE,
 } from './types/constants';
-import { getUserMatchedList, queryAllServers } from './utils/utils';
+import {
+    getUserMatchedList,
+    queryAllServers,
+    findMapByQuery,
+    getServersForMap,
+} from './utils/utils';
 import {
     printChartPng,
     printHoursChartPng,
@@ -24,6 +31,7 @@ import { AnalysticsHoursTask } from './tasks/analyticsHoursTask';
 import { AnalysticsServerTask } from './tasks/analyticsServerTask';
 import { parseIgnoreSpace } from '../../utils/cmd';
 import { MapsDataService } from './services/mapsData.service';
+import { MapImageService } from './services/mapImage.service';
 import { CanvasImgService } from '../../services/canvasImg.service';
 import {
     serverCommandCache,
@@ -316,11 +324,69 @@ export const MapsCommandRegister: IRegister = {
         {
             name: 'maps',
             alias: 'm',
-            description: '查询所有 rwr 地图列表.[10s CD]',
-            hint: ['按地图顺序查询服务器状态列表: #maps'],
+            description: '查询所有 rwr 地图列表或指定地图详情.[10s CD]',
+            hint: [
+                '按地图顺序查询服务器状态列表: #maps',
+                '查询指定地图详情: #maps map105',
+            ],
             timesInterval: 10,
         },
         async (ctx) => {
+            if (ctx.params.size > 0) {
+                let query = '';
+                ctx.params.forEach((_v, k) => {
+                    if (!query) query = k;
+                });
+
+                const mapData = MapsDataService.getInst().getData();
+                const result = findMapByQuery(query, mapData);
+
+                if (result.type === 'none') {
+                    await ctx.reply(
+                        `未找到与"${query}"匹配的地图，请检查输入`,
+                    );
+                    return;
+                }
+
+                if (result.type === 'fuzzy') {
+                    const candidates = result.maps
+                        .slice(0, 10)
+                        .map((m) => `  - ${m.name} (${m.id})`)
+                        .join('\n');
+                    await ctx.reply(
+                        `找到多个匹配的地图，请缩小范围：\n${candidates}`,
+                    );
+                    return;
+                }
+
+                const serverList = await queryAllServers(
+                    ctx.env.SERVERS_MATCH_REGEX,
+                );
+                const servers = getServersForMap(result.map.id, serverList);
+
+                printMapDetailPng(
+                    result.map,
+                    servers,
+                    MAP_DETAIL_OUTPUT_FILE,
+                );
+
+                const mapImageService = MapImageService.getInst();
+                const sampleServer = servers[0];
+                const mapImageUrl = mapImageService.getImageUrl(
+                    sampleServer?.map_id ?? result.map.id,
+                    result.map.id,
+                );
+
+                let reply = `[CQ:image,file=${getStaticHttpPath(ctx.env, MAP_DETAIL_OUTPUT_FILE)},cache=0,c=8]`;
+
+                if (mapImageUrl) {
+                    reply += `\n[CQ:image,file=${mapImageUrl},cache=0,c=8]`;
+                }
+
+                await ctx.reply(reply);
+                return;
+            }
+
             await executeSharedGroupCommand(ctx, {
                 command: 'maps',
                 params: {},
@@ -347,9 +413,11 @@ export const MapsCommandRegister: IRegister = {
             });
         },
     ),
+    parseParams: (msg: string) => parseIgnoreSpace(['#maps', '#m'], msg),
     init: async (env: GlobalEnv): Promise<void> => {
         MapsDataService.init(env.MAPS_DATA_FILE);
         await MapsDataService.getInst().refresh();
+        await MapImageService.getInst().init(env);
     },
 };
 

--- a/src/commands/servers/services/mapImage.service.test.ts
+++ b/src/commands/servers/services/mapImage.service.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { MapImageService } from './mapImage.service';
+import { GlobalEnv } from '../../../types';
+
+const FIXTURE_CONFIG = {
+    images: [
+        {
+            path: 'media/packages/hell_diver/maps/BloodandFlowers_01',
+            image: 'map-images/BloodandFlowers_01.png',
+            name: 'Blood and Flowers',
+        },
+        {
+            path: 'media/packages/GFL_Castling/maps/map13_2',
+            image: 'map-images/map13_2.png',
+        },
+        {
+            path: 'media/packages/rwr/maps/map105',
+            image: 'https://example.com/map105.png',
+        },
+    ],
+};
+
+function makeMockEnv(overrides?: Partial<GlobalEnv>): GlobalEnv {
+    return {
+        PORT: 3000,
+        HOSTNAME: 'localhost',
+        STATIC_HTTP_PATH: '',
+        START_MATCH: '#',
+        REMOTE_URL: '',
+        LISTEN_GROUP: '',
+        SERVERS_MATCH_REGEX: '',
+        SERVERS_FALLBACK_URL: '',
+        ADMIN_QQ_LIST: [],
+        ACTIVE_COMMANDS: [],
+        WELCOME_TEMPLATE: '',
+        WEBSITE_DATA_FILE: '',
+        TDOLL_DATA_FILE: '',
+        TDOLL_SKIN_DATA_FILE: '',
+        MAPS_DATA_FILE: '',
+        QA_DATA_FILE: '',
+        OPENAI_API_KEY: '',
+        OPENAI_API_URL: '',
+        OPENAI_TABLE_NAME: '',
+        IMGPROXY_URL: '',
+        OUTPUT_BG_IMG: '',
+        TOKEN: '',
+        MODERATORS: [],
+        MODERATOR_BADGE: '',
+        ...overrides,
+    };
+}
+
+describe('MapImageService', () => {
+    let tmpDir: string;
+    let configPath: string;
+
+    beforeEach(async () => {
+        MapImageService.resetInst();
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mapimage-test-'));
+        configPath = path.join(tmpDir, 'map_images.json');
+        await fs.writeFile(configPath, JSON.stringify(FIXTURE_CONFIG));
+    });
+
+    afterEach(async () => {
+        MapImageService.resetInst();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('loadConfig', () => {
+        it('should load config and build fullPathMap and shortNameMap', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(
+                service.getImageUrl(
+                    'media/packages/hell_diver/maps/BloodandFlowers_01',
+                ),
+            ).toBe(
+                'http://localhost:3000/out/map-images/BloodandFlowers_01.png',
+            );
+            expect(
+                service.getImageUrl(
+                    'media/packages/GFL_Castling/maps/map13_2',
+                ),
+            ).toBe('http://localhost:3000/out/map-images/map13_2.png');
+        });
+
+        it('should handle missing config file gracefully', async () => {
+            const env = makeMockEnv({
+                MAP_IMAGE_CONFIG_FILE: '/nonexistent/path.json',
+            });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(service.getImageUrl('any-map-id')).toBeUndefined();
+        });
+
+        it('should not load config when MAP_IMAGE_CONFIG_FILE is not set', async () => {
+            const env = makeMockEnv();
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(
+                service.getImageUrl(
+                    'media/packages/hell_diver/maps/BloodandFlowers_01',
+                ),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('getImageUrl', () => {
+        it('should match by full path (exact)', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl(
+                'media/packages/hell_diver/maps/BloodandFlowers_01',
+            );
+            expect(url).toBe(
+                'http://localhost:3000/out/map-images/BloodandFlowers_01.png',
+            );
+        });
+
+        it('should fall back to short name match', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl('BloodandFlowers_01');
+            expect(url).toBe(
+                'http://localhost:3000/out/map-images/BloodandFlowers_01.png',
+            );
+        });
+
+        it('should use mapShortId parameter for short name fallback', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl(
+                'unknown_full_path',
+                'BloodandFlowers_01',
+            );
+            expect(url).toBe(
+                'http://localhost:3000/out/map-images/BloodandFlowers_01.png',
+            );
+        });
+
+        it('should fall back to baseUrl when no config match', async () => {
+            const env = makeMockEnv({
+                MAP_IMAGE_BASE_URL: 'https://img.example.com/maps/',
+            });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl('map999');
+            expect(url).toBe('https://img.example.com/maps/map999.png');
+        });
+
+        it('should return undefined when no match and no baseUrl', async () => {
+            const env = makeMockEnv();
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl('nonexistent');
+            expect(url).toBeUndefined();
+        });
+
+        it('should prefer full path over short name', async () => {
+            const configWithConflict = {
+                images: [
+                    {
+                        path: 'media/packages/A/maps/map105',
+                        image: 'https://example.com/A/map105.png',
+                    },
+                    {
+                        path: 'media/packages/B/maps/map105',
+                        image: 'https://example.com/B/map105.png',
+                    },
+                ],
+            };
+            await fs.writeFile(
+                configPath,
+                JSON.stringify(configWithConflict),
+            );
+
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(service.getImageUrl('media/packages/A/maps/map105')).toBe(
+                'https://example.com/A/map105.png',
+            );
+            expect(service.getImageUrl('media/packages/B/maps/map105')).toBe(
+                'https://example.com/B/map105.png',
+            );
+
+            // Short name match returns the last loaded one (B overwrites A in shortNameMap)
+            expect(service.getImageUrl('map105')).toBe(
+                'https://example.com/B/map105.png',
+            );
+        });
+    });
+
+    describe('resolveImageUrl', () => {
+        it('should resolve relative path via getStaticHttpPath', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            const url = service.getImageUrl(
+                'media/packages/hell_diver/maps/BloodandFlowers_01',
+            );
+            expect(url).toBe(
+                'http://localhost:3000/out/map-images/BloodandFlowers_01.png',
+            );
+        });
+
+        it('should resolve /out/ prefixed path', async () => {
+            const config = {
+                images: [
+                    {
+                        path: 'test/map',
+                        image: '/out/map-images/test.png',
+                    },
+                ],
+            };
+            await fs.writeFile(configPath, JSON.stringify(config));
+
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(service.getImageUrl('test/map')).toBe(
+                'http://localhost:3000/out/map-images/test.png',
+            );
+        });
+
+        it('should keep http URLs as-is', async () => {
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(
+                service.getImageUrl('media/packages/rwr/maps/map105'),
+            ).toBe('https://example.com/map105.png');
+        });
+
+        it('should use STATIC_HTTP_PATH when set', async () => {
+            const env = makeMockEnv({
+                MAP_IMAGE_CONFIG_FILE: configPath,
+                STATIC_HTTP_PATH: 'cdn.example.com:8080',
+            });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(
+                service.getImageUrl(
+                    'media/packages/hell_diver/maps/BloodandFlowers_01',
+                ),
+            ).toBe(
+                'http://cdn.example.com:8080/out/map-images/BloodandFlowers_01.png',
+            );
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should return image as-is when env is not set (no init)', () => {
+            const service = MapImageService.getInst();
+            // No init called, env is undefined
+            expect(service.getImageUrl('any-map')).toBeUndefined();
+        });
+
+        it('should handle empty images array', async () => {
+            const config = { images: [] };
+            await fs.writeFile(configPath, JSON.stringify(config));
+
+            const env = makeMockEnv({ MAP_IMAGE_CONFIG_FILE: configPath });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(service.getImageUrl('any-map')).toBeUndefined();
+        });
+
+        it('should handle config with only baseUrl fallback', async () => {
+            const env = makeMockEnv({
+                MAP_IMAGE_BASE_URL: 'https://cdn.example.com/maps/',
+            });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(service.getImageUrl('someMap')).toBe(
+                'https://cdn.example.com/maps/someMap.png',
+            );
+        });
+
+        it('should use mapShortId param for baseUrl fallback', async () => {
+            const env = makeMockEnv({
+                MAP_IMAGE_BASE_URL: 'https://cdn.example.com/maps/',
+            });
+            const service = MapImageService.getInst();
+            await service.init(env);
+
+            expect(
+                service.getImageUrl(
+                    'media/packages/rwr/maps/someMap',
+                    'someMap',
+                ),
+            ).toBe('https://cdn.example.com/maps/someMap.png');
+        });
+    });
+});

--- a/src/commands/servers/services/mapImage.service.ts
+++ b/src/commands/servers/services/mapImage.service.ts
@@ -4,6 +4,7 @@ import { IMapImageConfigFile } from '../types/types';
 import { getStaticHttpPath } from '../../../utils/cmdreq';
 import { getMapShortName } from '../utils/utils';
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 
 export class MapImageService {
     private static inst: MapImageService | undefined;
@@ -35,8 +36,9 @@ export class MapImageService {
     }
 
     private async loadConfig(filePath: string) {
+        const resolvedPath = path.resolve(filePath);
         try {
-            const raw = await fs.readFile(filePath, 'utf8');
+            const raw = await fs.readFile(resolvedPath, 'utf8');
             const config = JSON.parse(raw) as IMapImageConfigFile;
             if (!Array.isArray(config.images)) {
                 logger.warn(
@@ -56,7 +58,10 @@ export class MapImageService {
                 `[MapImageService] Loaded ${config.images.length} entries`,
             );
         } catch (e) {
-            logger.warn('[MapImageService] Failed to load config:', e);
+            logger.warn(
+                `[MapImageService] Failed to load config from "${resolvedPath}":`,
+                e,
+            );
         }
     }
 

--- a/src/commands/servers/services/mapImage.service.ts
+++ b/src/commands/servers/services/mapImage.service.ts
@@ -1,0 +1,88 @@
+import { logger } from '../../../utils/logger';
+import { GlobalEnv } from '../../../types';
+import { IMapImageConfigFile } from '../types/types';
+import { getStaticHttpPath } from '../../../utils/cmdreq';
+import { getMapShortName } from '../utils/utils';
+import * as fs from 'node:fs/promises';
+
+export class MapImageService {
+    private static inst: MapImageService | undefined;
+    private fullPathMap: Map<string, string> = new Map();
+    private shortNameMap: Map<string, string> = new Map();
+    private env?: GlobalEnv;
+    private baseUrlFallback?: string;
+
+    private constructor() {}
+
+    static getInst(): MapImageService {
+        if (!MapImageService.inst) {
+            MapImageService.inst = new MapImageService();
+        }
+        return MapImageService.inst;
+    }
+
+    static resetInst() {
+        MapImageService.inst = undefined;
+    }
+
+    async init(env: GlobalEnv) {
+        this.env = env;
+        this.baseUrlFallback = env.MAP_IMAGE_BASE_URL;
+
+        if (env.MAP_IMAGE_CONFIG_FILE) {
+            await this.loadConfig(env.MAP_IMAGE_CONFIG_FILE);
+        }
+    }
+
+    private async loadConfig(filePath: string) {
+        try {
+            const raw = await fs.readFile(filePath, 'utf8');
+            const config = JSON.parse(raw) as IMapImageConfigFile;
+            if (!Array.isArray(config.images)) {
+                logger.warn(
+                    '[MapImageService] Invalid config: missing "images" array',
+                );
+                return;
+            }
+            for (const item of config.images) {
+                const resolvedUrl = this.resolveImageUrl(item.image);
+                this.fullPathMap.set(item.path, resolvedUrl);
+                const shortName = getMapShortName(item.path);
+                if (shortName) {
+                    this.shortNameMap.set(shortName, resolvedUrl);
+                }
+            }
+            logger.info(
+                `[MapImageService] Loaded ${config.images.length} entries`,
+            );
+        } catch (e) {
+            logger.warn('[MapImageService] Failed to load config:', e);
+        }
+    }
+
+    private resolveImageUrl(image: string): string {
+        if (!this.env) return image;
+        if (image.startsWith('/out/')) {
+            return getStaticHttpPath(this.env, image.slice(5));
+        }
+        if (!image.startsWith('http')) {
+            return getStaticHttpPath(this.env, image);
+        }
+        return image;
+    }
+
+    getImageUrl(mapId: string, mapShortId?: string): string | undefined {
+        const direct = this.fullPathMap.get(mapId);
+        if (direct) return direct;
+
+        const shortKey = mapShortId || getMapShortName(mapId);
+        const byShort = this.shortNameMap.get(shortKey);
+        if (byShort) return byShort;
+
+        if (this.baseUrlFallback && shortKey) {
+            return `${this.baseUrlFallback}${shortKey}.png`;
+        }
+
+        return undefined;
+    }
+}

--- a/src/commands/servers/types/constants.ts
+++ b/src/commands/servers/types/constants.ts
@@ -11,6 +11,7 @@ export const ANALYSIS_HOURS_OUTPUT_FILE = 'analysis_hours.png';
 export const ANALYSIS_HOURS_DATA_FILE = 'analysis_hours.json';
 
 export const MAPS_OUTPUT_FILE = 'maps.png';
+export const MAP_DETAIL_OUTPUT_FILE = 'map_detail.png';
 
 export const PLAYERS_OUTPUT_FILE = 'players.png';
 

--- a/src/commands/servers/types/types.ts
+++ b/src/commands/servers/types/types.ts
@@ -64,3 +64,13 @@ export interface IServerAnalyticsRecord {
     serverName: string;
     data: IServerAnalyticsHourlyData[];
 }
+
+export interface IMapImageConfigItem {
+    path: string;
+    image: string;
+    name?: string;
+}
+
+export interface IMapImageConfigFile {
+    images: IMapImageConfigItem[];
+}

--- a/src/commands/servers/utils/canvas.ts
+++ b/src/commands/servers/utils/canvas.ts
@@ -9,6 +9,7 @@ import { ServersCanvas } from '../canvas/serversCanvas';
 import { PlayersCanvas } from '../canvas/playersCanvas';
 import { WhereisCanvas } from '../canvas/whereisCanvas';
 import { MapsCanvas } from '../canvas/mapsCanvas';
+import { MapDetailCanvas } from '../canvas/mapDetailCanvas';
 
 const OUTPUT_FOLDER = 'out';
 
@@ -101,6 +102,24 @@ export const printMapPng = (
     }
 
     const outputPath = new MapsCanvas(serverList, mapData, fileName).render();
+
+    return outputPath;
+};
+
+export const printMapDetailPng = (
+    map: IMapDataItem,
+    servers: OnlineServerItem[],
+    fileName: string,
+): string => {
+    if (!fs.existsSync(OUTPUT_FOLDER)) {
+        fs.mkdirSync(OUTPUT_FOLDER);
+    }
+
+    const outputPath = new MapDetailCanvas(
+        map,
+        servers,
+        fileName,
+    ).render();
 
     return outputPath;
 };

--- a/src/commands/servers/utils/utils.test.ts
+++ b/src/commands/servers/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { OnlineServerItem } from '../types/types';
+import { OnlineServerItem, IMapDataItem } from '../types/types';
 import {
     getServerInfoDisplaySectionText,
     getCountColor,
@@ -9,6 +9,9 @@ import {
     getWhereisHeaderSectionText,
     getWhereisFooterSectionText,
     getPlayersInServer,
+    findMapByQuery,
+    getServersForMap,
+    buildMapDetailReply,
 } from './utils';
 
 const MOCK_CT_SERVER_ITEM: OnlineServerItem = {
@@ -238,5 +241,151 @@ describe('getPlayersInServer', () => {
             'A8',
             'A9',
         ]);
+    });
+});
+
+const MOCK_MAP_DATA: IMapDataItem[] = [
+    { id: 'map105', name: 'Sunset Beach' },
+    { id: 'map13_2', name: 'Castling Storm' },
+    { id: 'test_map', name: 'Test Arena' },
+    { id: 'urban_01', name: 'Urban Warfare' },
+    { id: 'urban_02', name: 'Urban Night' },
+];
+
+describe('findMapByQuery', () => {
+    it.concurrent('exact match by id', () => {
+        const result = findMapByQuery('map105', MOCK_MAP_DATA);
+        expect(result.type).toBe('exact');
+        if (result.type === 'exact') {
+            expect(result.map.id).toBe('map105');
+        }
+    });
+
+    it.concurrent('exact match by name', () => {
+        const result = findMapByQuery('Sunset Beach', MOCK_MAP_DATA);
+        expect(result.type).toBe('exact');
+        if (result.type === 'exact') {
+            expect(result.map.id).toBe('map105');
+        }
+    });
+
+    it.concurrent('fuzzy match single result upgrades to exact', () => {
+        const result = findMapByQuery('test', MOCK_MAP_DATA);
+        expect(result.type).toBe('exact');
+        if (result.type === 'exact') {
+            expect(result.map.id).toBe('test_map');
+        }
+    });
+
+    it.concurrent('fuzzy match multiple results', () => {
+        const result = findMapByQuery('urban', MOCK_MAP_DATA);
+        expect(result.type).toBe('fuzzy');
+        if (result.type === 'fuzzy') {
+            expect(result.maps.length).toBe(2);
+        }
+    });
+
+    it.concurrent('no match', () => {
+        const result = findMapByQuery('nonexistent', MOCK_MAP_DATA);
+        expect(result.type).toBe('none');
+    });
+
+    it.concurrent('case insensitive', () => {
+        const result = findMapByQuery('MAP105', MOCK_MAP_DATA);
+        expect(result.type).toBe('exact');
+        if (result.type === 'exact') {
+            expect(result.map.id).toBe('map105');
+        }
+    });
+
+    it.concurrent('case insensitive name', () => {
+        const result = findMapByQuery('sunset beach', MOCK_MAP_DATA);
+        expect(result.type).toBe('exact');
+        if (result.type === 'exact') {
+            expect(result.map.id).toBe('map105');
+        }
+    });
+});
+
+describe('getServersForMap', () => {
+    const mockServers: OnlineServerItem[] = [
+        {
+            ...MOCK_CT_SERVER_ITEM,
+            name: 'Server A',
+            map_id: 'media/packages/GFL_Castling/maps/map13_2',
+            current_players: 5,
+            max_players: 20,
+        },
+        {
+            ...MOCK_CT_SERVER_ITEM,
+            name: 'Server B',
+            map_id: 'media/packages/GFL_Castling/maps/map13_2',
+            current_players: 15,
+            max_players: 32,
+        },
+        {
+            ...MOCK_CT_SERVER_ITEM,
+            name: 'Server C',
+            map_id: 'media/packages/other/maps/map105',
+            current_players: 10,
+            max_players: 20,
+        },
+    ];
+
+    it.concurrent('returns matching servers sorted by players desc', () => {
+        const result = getServersForMap('map13_2', mockServers);
+        expect(result.length).toBe(2);
+        expect(result[0].name).toBe('Server B');
+        expect(result[1].name).toBe('Server A');
+    });
+
+    it.concurrent('returns empty for no match', () => {
+        const result = getServersForMap('nonexistent', mockServers);
+        expect(result.length).toBe(0);
+    });
+});
+
+describe('buildMapDetailReply', () => {
+    const mockMap: IMapDataItem = { id: 'map105', name: 'Sunset Beach' };
+
+    it.concurrent('with servers and image URL', () => {
+        const servers: OnlineServerItem[] = [
+            {
+                ...MOCK_CT_SERVER_ITEM,
+                name: 'Server A',
+                current_players: 10,
+                max_players: 20,
+            },
+        ];
+        const reply = buildMapDetailReply(
+            mockMap,
+            servers,
+            'http://example.com/map105.png',
+        );
+        expect(reply).toContain('📍 地图: Sunset Beach (map105)');
+        expect(reply).toContain('Server A  | 10/20 玩家 | 在线');
+        expect(reply).toContain('共 1 个服务器正在运行此地图');
+        expect(reply).toContain('[CQ:image,file=http://example.com/map105.png');
+    });
+
+    it.concurrent('with no servers and no image URL', () => {
+        const reply = buildMapDetailReply(mockMap, []);
+        expect(reply).toContain('📍 地图: Sunset Beach (map105)');
+        expect(reply).toContain('当前没有服务器正在运行此地图');
+        expect(reply).toContain('共 0 个服务器正在运行此地图');
+        expect(reply).not.toContain('[CQ:image');
+    });
+
+    it.concurrent('full server shows 已满', () => {
+        const servers: OnlineServerItem[] = [
+            {
+                ...MOCK_CT_SERVER_ITEM,
+                name: 'Full Server',
+                current_players: 20,
+                max_players: 20,
+            },
+        ];
+        const reply = buildMapDetailReply(mockMap, servers);
+        expect(reply).toContain('Full Server  | 20/20 玩家 | 已满');
     });
 });

--- a/src/commands/servers/utils/utils.ts
+++ b/src/commands/servers/utils/utils.ts
@@ -430,3 +430,67 @@ export const getPlayersInServer = (server: OnlineServerItem): string[] => {
 
     return playersArr;
 };
+
+export type MapQueryResult =
+    | { type: 'exact'; map: IMapDataItem }
+    | { type: 'fuzzy'; maps: IMapDataItem[] }
+    | { type: 'none' };
+
+export const findMapByQuery = (
+    query: string,
+    mapData: IMapDataItem[],
+): MapQueryResult => {
+    const exactId = mapData.find((m) => m.id === query);
+    if (exactId) return { type: 'exact', map: exactId };
+
+    const exactName = mapData.find((m) => m.name === query);
+    if (exactName) return { type: 'exact', map: exactName };
+
+    const queryLower = query.toLowerCase();
+    const fuzzy = mapData.filter(
+        (m) =>
+            m.id.toLowerCase().includes(queryLower) ||
+            m.name.toLowerCase().includes(queryLower),
+    );
+    if (fuzzy.length === 1) return { type: 'exact', map: fuzzy[0] };
+    if (fuzzy.length > 1) return { type: 'fuzzy', maps: fuzzy };
+
+    return { type: 'none' };
+};
+
+export const getServersForMap = (
+    mapId: string,
+    serverList: OnlineServerItem[],
+): OnlineServerItem[] => {
+    return serverList
+        .filter((s) => getMapShortName(s.map_id) === mapId)
+        .sort((a, b) => b.current_players - a.current_players);
+};
+
+export const buildMapDetailReply = (
+    map: IMapDataItem,
+    servers: OnlineServerItem[],
+    mapImageUrl?: string,
+): string => {
+    let reply = `📍 地图: ${map.name} (${map.id})\n`;
+    reply += `━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+
+    if (servers.length === 0) {
+        reply += `当前没有服务器正在运行此地图\n`;
+    } else {
+        for (const s of servers) {
+            const status =
+                s.current_players === s.max_players ? '已满' : '在线';
+            reply += `  ${s.name}  | ${s.current_players}/${s.max_players} 玩家 | ${status}\n`;
+        }
+    }
+
+    reply += `━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+    reply += `共 ${servers.length} 个服务器正在运行此地图`;
+
+    if (mapImageUrl) {
+        reply += `\n[CQ:image,file=${mapImageUrl},cache=0,c=8]`;
+    }
+
+    return reply;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export interface GlobalEnv {
     PG_DB?: string;
     PG_USER?: string;
     PG_PASSWORD?: string;
+    MAP_IMAGE_BASE_URL?: string;
+    MAP_IMAGE_CONFIG_FILE?: string;
 }
 
 export interface BaseEvent {


### PR DESCRIPTION
…ge support

- Add MapDetailCanvas for rendering map details with server list
- Add MapImageService for loading and resolving map images from config
- Extend #maps command to accept a map query parameter for detail view
- Implement fuzzy map search (findMapByQuery) and server filtering (getServersForMap)
- Add sync script for fetching remote map images
- Add new environment variables MAP_IMAGE_BASE_URL and MAP_IMAGE_CONFIG_FILE
- Update types, constants, and utility exports accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `#maps` now supports querying a specific map’s details, showing which servers run it, their status, and an optional map image.
  * Generates a detailed map image output for map-detail replies.

* **Tests**
  * Added comprehensive tests for map lookup, server filtering/sorting, image URL resolution, and reply composition.

* **Chores**
  * Added support for configurable map image sources and a CLI to sync remote map image metadata.

* **Documentation**
  * Updated docs and README with map-image config and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rwr-infra/rwr-qq-bot/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->