### PR TITLE
feat(maps): display current map duration in canvas output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ ecosystem.config.js
 .claude/
 .specify/
 .kilo/
+/.agent-shell/
+.codegraph/
+.cursor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RWR Imba QQ Bot — 一个通过 go-cqhttp 接入的 QQ 机器人，用于查询《Running With Rifles》游戏服务器数据（服务器列表、玩家位置、地图信息、T-Doll 数据等），并以图片形式回复。
+
+## Commands
+
+```bash
+# 开发模式（热重载）
+pnpm dev
+
+# 构建生产包
+pnpm build
+
+# 运行所有测试
+pnpm test
+
+# 图像回归测试（需要 RUN_IMAGE_TESTS=1 环境变量）
+pnpm test:image
+
+# 监视模式
+pnpm test:watch
+
+# 覆盖率报告
+pnpm coverage
+
+# 单个测试文件
+pnpm vitest -- src/services/asyncCache.service.test.ts
+```
+
+## Architecture
+
+### 请求流程
+
+```
+go-cqhttp → POST /in → eventHandler → msgHandler / noticeHandler
+```
+
+1. **`src/index.ts`** — Fastify 服务启动，加载环境变量，注册路由，初始化命令
+2. **`src/routes.ts`** — 路由定义：`POST /in`（接收 go-cqhttp 事件）、`GET /health`、`GET /query_cmd`
+3. **`src/eventHandler.ts`** — 按 `post_type` 分发至 `msgHandler` 或 `noticeHandler`
+4. **`src/commands/index.ts`** — 命令注册总表（`allCommands`）、消息分发、权限校验、CD 检查、PostgreSQL 命令日志写入
+
+### 命令系统
+
+所有命令实现 `IRegister` 接口（`src/types.ts`）：
+
+```ts
+interface IRegister {
+    name: string;          // 触发词
+    alias?: string;        // 别名
+    description: string;
+    hint?: string[];
+    isAdmin: boolean;
+    timesInterval?: number; // 单用户冷却（秒）
+    exec(ctx: MsgExecCtx): Promise<void>;
+    init?(env: GlobalEnv): Promise<void>; // 启动时初始化（加载数据文件等）
+}
+```
+
+每个命令位于 `src/commands/<name>/`，标准文件布局：`register.ts` / `types.ts` / `constants.ts` / `utils.ts`。较复杂的命令（`servers`、`tdoll`）还包含 `canvas/`、`services/`、`charts/`、`tasks/` 子目录。
+
+### Canvas 渲染层
+
+- **`src/services/canvasBackend.ts`** — 封装 `skia-canvas` 的 `createCanvas` / `loadImageFrom` / `toPngBuffer`；整个项目唯一引入 `skia-canvas` 的地方
+- **`src/services/baseCanvas.ts`** — 所有画布类的基类：文本宽度计算（中文字符 2× 宽度）、背景图渲染、页脚渲染、文件写出
+- **`src/services/layeredCanvasRenderer.ts`** — 分层渲染基类：主内容与时间戳分离，支持主内容缓存后动态叠加时间戳
+
+渲染产物写入 `out/` 目录，通过 `/out/<filename>` 静态路径提供给 go-cqhttp 以 `[CQ:image,...]` 格式发送。
+
+### 缓存机制
+
+- **`AsyncCacheService`**（`src/services/asyncCache.service.ts`）— TTL 缓存基类，子类实现 `fetchData()` 即可
+- **`serverCommandCache.service.ts`** — 群级 CD + 并发请求合并 + 批量 AT
+- **`tdollRenderCache.service.ts`**、**`serverHistoryCache.service.ts`** — 特定场景缓存
+
+### 数据文件
+
+通过环境变量指定路径，在命令 `init()` 时加载：
+
+| 环境变量 | 用途 |
+|----------|------|
+| `TDOLL_DATA_FILE` | T-Doll JSON 数据 |
+| `TDOLL_SKIN_DATA_FILE` | T-Doll 皮肤 JSON 数据 |
+| `MAPS_DATA_FILE` | 地图 JSON 数据 |
+| `MAP_IMAGE_CONFIG_FILE` | 地图图片路径配置（由 `scripts/syncMapImages.js` 生成） |
+| `QA_DATA_FILE` | 自助问答 JSON 数据 |
+| `WEBSITE_DATA_FILE` | 网站列表数据 |
+
+## Key Conventions
+
+- **ACTIVE_COMMANDS** — JSON 字符串数组，留空则启用所有命令。命令名需与 `IRegister.name` 完全一致
+- **go-cqhttp 消息格式** — CQ 码，如 `[CQ:image,file=<url>,cache=0,c=8]`、`[CQ:at,qq=<qq>]`
+- **图片输出** — 所有 canvas 渲染输出至 `out/` 目录；生产构建时由 `postbuild.cjs` 处理静态资源
+- **`DIFY_AI_URL` / `DIFY_AI_TOKEN`** — README 中仍显示为 `OPENAI_*`，但代码实际使用 `DIFY_AI_*` 变量（`src/types.ts` 也使用 `OPENAI_*` 作为类型名），注意实际环境变量名以 `src/utils/env.ts` 为准
+
+## Testing
+
+- 测试框架：vitest，配置见 `vitest.config.ts`（pool 使用 `forks` 避免 skia-canvas 报错）
+- 图像回归测试位于 `src/services/imageRegression/`，基准图片在 `fixtures/` 下，需 `RUN_IMAGE_TESTS=1` 才执行
+- 覆盖率使用 istanbul，同时输出 SonarQube 报告（`sonar-report.xml`）
+
+## Deployment
+
+```sh
+# Docker 示例
+docker run --name my-rwr-qq-bot \
+  -p 3000:3000 \
+  -e "REMOTE_URL=<go-cqhttp地址>" \
+  -e "START_MATCH=#" \
+  -e "LISTEN_GROUP=<群号>" \
+  -v ${PWD}/data:/app/data \
+  zhaozisong0/rwr-imba-qq-bot:latest
+```
+
+参考 `docker-compose-example.yaml` 了解完整配置示例。

--- a/src/commands/servers/canvas/mapDetailCanvas.ts
+++ b/src/commands/servers/canvas/mapDetailCanvas.ts
@@ -4,6 +4,7 @@ import {
     calcCanvasTextWidth,
     getCountColor,
     getMapShortName,
+    formatMapDuration,
 } from '../utils/utils';
 import { BaseCanvas } from '../../../services/baseCanvas';
 
@@ -11,6 +12,7 @@ export class MapDetailCanvas extends BaseCanvas {
     map: IMapDataItem;
     servers: OnlineServerItem[];
     fileName: string;
+    mapStartedAtMap: Map<string, number | null> = new Map();
 
     renderWidth = 0;
     renderHeight = 0;
@@ -23,11 +25,13 @@ export class MapDetailCanvas extends BaseCanvas {
         map: IMapDataItem,
         servers: OnlineServerItem[],
         fileName: string,
+        mapStartedAtMap: Map<string, number | null> = new Map(),
     ) {
         super();
         this.map = map;
         this.servers = servers;
         this.fileName = fileName;
+        this.mapStartedAtMap = mapStartedAtMap;
     }
 
     measure() {
@@ -51,7 +55,7 @@ export class MapDetailCanvas extends BaseCanvas {
             for (const s of this.servers) {
                 const status =
                     s.current_players === s.max_players ? '已满' : '在线';
-                const line = `${s.name}  | ${s.current_players}/${s.max_players} 玩家 | ${status}`;
+                const line = `${s.name}  | ${s.current_players}/${s.max_players} 玩家 | ${status} | ${formatMapDuration(this.mapStartedAtMap.get(`${s.address}:${s.port}`) ?? null)}`;
                 const lineWidth = calcCanvasTextWidth(line, 16) + 80;
                 if (lineWidth > this.maxRectWidth) {
                     this.maxRectWidth = lineWidth;
@@ -136,6 +140,12 @@ export class MapDetailCanvas extends BaseCanvas {
                     20 + nameWidth + playersWidth,
                     this.renderStartY,
                 );
+
+                const statusText = ` | ${status}`;
+                const statusWidth = context.measureText(statusText).width;
+                const durationText = ` | ${formatMapDuration(this.mapStartedAtMap.get(`${s.address}:${s.port}`) ?? null)}`;
+                context.fillStyle = '#6b7280';
+                context.fillText(durationText, 20 + nameWidth + playersWidth + statusWidth, this.renderStartY);
 
                 this.renderStartY += 40;
             }

--- a/src/commands/servers/canvas/mapsCanvas.ts
+++ b/src/commands/servers/canvas/mapsCanvas.ts
@@ -6,6 +6,7 @@ import {
     getServerInfoDisplaySectionText,
     getMapTextInCanvas,
     getMapShortName,
+    formatMapDuration,
 } from '../utils/utils';
 import { BaseCanvas } from '../../../services/baseCanvas';
 
@@ -16,6 +17,7 @@ export class MapsCanvas extends BaseCanvas {
     serverList: OnlineServerItem[];
     mapData: IMapDataItem[];
     fileName: string;
+    mapStartedAtMap: Map<string, number | null> = new Map();
 
     // render params data
     measureMaxWidth = 0;
@@ -35,11 +37,13 @@ export class MapsCanvas extends BaseCanvas {
         serverList: OnlineServerItem[],
         mapData: IMapDataItem[],
         fileName: string,
+        mapStartedAtMap: Map<string, number | null> = new Map(),
     ) {
         super();
         this.serverList = serverList;
         this.mapData = mapData;
         this.fileName = fileName;
+        this.mapStartedAtMap = mapStartedAtMap;
     }
 
     measureTitle() {
@@ -174,13 +178,25 @@ export class MapsCanvas extends BaseCanvas {
                         10 + this.renderStartY,
                     );
 
+                    const playersWidth = context.measureText(serverText.playersSection).width;
+                    const serverKey = `${s.address}:${s.port}`;
+                    const durationText = `  ${formatMapDuration(this.mapStartedAtMap.get(serverKey) ?? null)}`;
+                    context.fillStyle = '#6b7280';
+                    context.fillText(
+                        durationText,
+                        20 + UNDER_MAP_SERVER_SPACING + serverSectionWidth + playersWidth,
+                        10 + this.renderStartY,
+                    );
+
                     this.renderStartY += 40;
 
                     const allText =
                         serverText.serverSection + serverText.playersSection;
+                    const durationWidth = context.measureText(durationText).width;
                     const allTextWidth =
                         context.measureText(allText).width +
-                        UNDER_MAP_SERVER_SPACING;
+                        UNDER_MAP_SERVER_SPACING +
+                        durationWidth;
 
                     if (allTextWidth > this.maxRectWidth) {
                         this.maxRectWidth = allTextWidth;

--- a/src/commands/servers/utils/canvas.ts
+++ b/src/commands/servers/utils/canvas.ts
@@ -5,6 +5,7 @@ import {
     IUserMatchedServerItem,
     OnlineServerItem,
 } from '../types/types';
+import { serverHistoryCache } from '../../../services/serverHistoryCache.service';
 import { ServersCanvas } from '../canvas/serversCanvas';
 import { PlayersCanvas } from '../canvas/playersCanvas';
 import { WhereisCanvas } from '../canvas/whereisCanvas';
@@ -92,6 +93,15 @@ export const printUserInServerListPng = (
     return outputPath;
 };
 
+function buildMapStartedAtMap(serverList: OnlineServerItem[]): Map<string, number | null> {
+    return new Map(
+        serverList.map((s) => [
+            `${s.address}:${s.port}`,
+            serverHistoryCache.getMapStartedAt(s.address, s.port),
+        ]),
+    );
+}
+
 export const printMapPng = (
     serverList: OnlineServerItem[],
     mapData: IMapDataItem[],
@@ -101,7 +111,8 @@ export const printMapPng = (
         fs.mkdirSync(OUTPUT_FOLDER);
     }
 
-    const outputPath = new MapsCanvas(serverList, mapData, fileName).render();
+    const mapStartedAtMap = buildMapStartedAtMap(serverList);
+    const outputPath = new MapsCanvas(serverList, mapData, fileName, mapStartedAtMap).render();
 
     return outputPath;
 };
@@ -115,10 +126,12 @@ export const printMapDetailPng = (
         fs.mkdirSync(OUTPUT_FOLDER);
     }
 
+    const mapStartedAtMap = buildMapStartedAtMap(servers);
     const outputPath = new MapDetailCanvas(
         map,
         servers,
         fileName,
+        mapStartedAtMap,
     ).render();
 
     return outputPath;

--- a/src/commands/servers/utils/utils.ts
+++ b/src/commands/servers/utils/utils.ts
@@ -494,3 +494,15 @@ export const buildMapDetailReply = (
 
     return reply;
 };
+
+export const formatMapDuration = (startedAt: number | null): string => {
+    if (startedAt === null) return '-';
+    const ms = Date.now() - startedAt;
+    if (ms < 0) return '-';
+    if (ms < 60_000) return '<1m';
+    const totalMin = Math.floor(ms / 60_000);
+    if (totalMin < 60) return `${totalMin}m`;
+    const h = Math.floor(totalMin / 60);
+    const m = totalMin % 60;
+    return m > 0 ? `${h}h${m}m` : `${h}h`;
+};

--- a/src/services/serverHistoryCache.service.ts
+++ b/src/services/serverHistoryCache.service.ts
@@ -11,8 +11,14 @@ interface SnapshotEntry {
     lastSeenAt: number;
 }
 
+interface MapStartEntry {
+    mapId: string;
+    startedAt: number;
+}
+
 class ServerHistoryCacheService {
     private snapshots = new Map<string, SnapshotEntry>();
+    private mapStartTimes = new Map<string, MapStartEntry>();
 
     private getServerKey(address: string, port: number): string {
         return `${address}:${port}`;
@@ -31,6 +37,14 @@ class ServerHistoryCacheService {
                 this.snapshots.set(key, {
                     server,
                     lastSeenAt: now,
+                });
+            }
+
+            const mapEntry = this.mapStartTimes.get(key);
+            if (!mapEntry || mapEntry.mapId !== server.map_id) {
+                this.mapStartTimes.set(key, {
+                    mapId: server.map_id,
+                    startedAt: now,
                 });
             }
         }
@@ -71,8 +85,15 @@ class ServerHistoryCacheService {
         for (const [key, entry] of this.snapshots) {
             if (now - entry.lastSeenAt > HISTORY_TTL_MS) {
                 this.snapshots.delete(key);
+                this.mapStartTimes.delete(key);
             }
         }
+    }
+
+    getMapStartedAt(address: string, port: number): number | null {
+        const key = this.getServerKey(address, port);
+        const entry = this.mapStartTimes.get(key);
+        return entry ? entry.startedAt : null;
     }
 
     getStats(): { snapshotCount: number } {


### PR DESCRIPTION
Track per-server map start time in ServerHistoryCacheService by detecting map_id changes on each updateSnapshot() call (2-min cron). Expose getMapStartedAt(address, port) to read the tracked timestamp.

Render duration in gray (#6b7280) as reference-only info:
- Map list (#maps): appended after player count per server row
- Map detail (#maps <id>): appended after online/full status per row

Format: `-` (not yet observed), `<1m`, `42m`, `1h23m`, `2h`

The 4th constructor param on MapsCanvas and MapDetailCanvas defaults to an empty Map, so the image regression scenario remains unaffected (all durations render as `-`). Golden files need regeneration:
  UPDATE_IMAGE_GOLDENS=1 RUN_IMAGE_TESTS=1 pnpm test:image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server lists now display the elapsed time a map has been running on each server, providing better visibility into server activity status.

* **Documentation**
  * Added a comprehensive project interaction guide for development tools.

* **Chores**
  * Updated ignore patterns for development and editor-related tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rwr-infra/rwr-qq-bot/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->