### PR TITLE
feat(servers): add overview command to display server status overview…

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,6 +12,7 @@ import {
     WhereIsCommandRegister,
     PlayersCommandRegister,
     ServerAnalyticsCommandRegister,
+    ServerOverviewCommandRegister,
 } from './servers/register';
 import { RollCommandRegister } from './roll/register';
 import { logger } from '../utils/logger';
@@ -56,6 +57,7 @@ const allCommands: IRegister[] = [
     WhereIsCommandRegister,
     AnalyticsCommandRegister,
     ServerAnalyticsCommandRegister,
+    ServerOverviewCommandRegister,
     MapsCommandRegister,
     PlayersCommandRegister,
     RollCommandRegister,

--- a/src/commands/servers/README.md
+++ b/src/commands/servers/README.md
@@ -50,6 +50,37 @@
     -   参数 h: 查询近 24 小时的数据
 -   a: analytics 的别名
 
+## overview
+
+### 用途
+
+根据 SERVERS_MATCH_REGEX 筛选服务器, 生成一张卡片式三段布局的状态总览图片，与 `analytics`（时间序列折线图）形成差异化互补：
+
+-   段一·概览: 标题 + 4 张 KPI 卡片（在线服务器数 / 在线玩家·容量·占用率 / 总 Bots / 满员服务器）+ 近24小时在线趋势折线图（面积+折线+峰值点，右上标注 24h/7日峰值数字；数据缺失时自动隐藏）
+-   段二·服务器详情: 各服务器一行（斑马纹卡片）——服务器名、地图、玩家数（着色）、Bots 数、延迟（ICMP ping，着色：<80ms 绿 / <180ms 琥珀 / 更高红 / 超时灰）、地图时长
+-   段三·页脚: 渲染耗时与时间
+
+底色与 `servers`、`players` 一致（`#451a03`），可通过 `OUTPUT_BG_IMG` 叠加背景图层。
+
+### 数据来源
+
+-   实时快照: `queryAllServers`（聚合 KPI 与各服务器详情）
+-   服务器延迟: 对各服务器 `address` 并发 ICMP `ping`（逻辑参考 `check` 命令，见 `utils/ping.ts`）。需运行环境具备 `ping` 命令
+-   地图运行时长: `serverHistoryCache.getMapStartedAt` + `formatMapDuration`
+-   24小时 / 7日峰值趋势: 读取 `out/analysis_hours.json` / `out/analysis.json`（由 `AnalysticsHoursTask` / `AnalysticsTask` cron 写入）。文件缺失时趋势条自动隐藏
+
+> 该命令 `init()` 会幂等启动 `AnalysticsTask` / `AnalysticsHoursTask`，因此即便 `ACTIVE_COMMANDS` 未启用 `analytics`，总览仍能获得历史峰值趋势数据。
+
+### 环境变量
+
+-   SERVERS_MATCH_REGEX: 用于匹配服务器的正则表达式
+-   OUTPUT_BG_IMG: 将输出的图片添加背景图 layer 层, 位于底色上方
+
+### 注册的指令
+
+-   overview: 生成服务器状态总览图片.[15s CD]
+-   o: overview 的别名
+
 ## maps
 
 ### 用途

--- a/src/commands/servers/canvas/serverOverviewCanvas.ts
+++ b/src/commands/servers/canvas/serverOverviewCanvas.ts
@@ -1,0 +1,609 @@
+import { createCanvas, Canvas2DContext } from '../../../services/canvasBackend';
+import { BaseCanvas } from '../../../services/baseCanvas';
+import { buildCanvasFont } from '../../../services/canvasFonts';
+import { IServerOverviewStats, ITrendSummary } from '../types/types';
+import { formatMapDuration, getCountColor } from '../utils/utils';
+
+// ============================================================================
+// 布局常量
+// ============================================================================
+const WIDTH = 880;
+const PAD = 30;
+const CONTENT_W = WIDTH - PAD * 2;
+
+const TITLE_H = 56;
+
+const KPI_GAP = 16;
+const KPI_COUNT = 4;
+const KPI_CARD_W = (CONTENT_W - KPI_GAP * (KPI_COUNT - 1)) / KPI_COUNT;
+const KPI_CARD_H = 96;
+
+const TREND_H = 128;
+
+const SECTION_HEADER_H = 40;
+const DETAIL_COL_HEADER_H = 28;
+const DETAIL_ROW_H = 34;
+const SECTION_GAP = 18;
+
+const FOOTER_H = 40;
+
+// 配色(与 ServersCanvas/PlayersCanvas 家族一致: #451a03 暖棕底 + OUTPUT_BG_IMG 可叠加)
+const COLOR_BG = '#451a03';
+const COLOR_CARD = 'rgba(0, 0, 0, 0.28)'; // 半透明深色面板, 叠在底色或背景图上均协调
+const COLOR_ACCENT = '#f48225';
+const COLOR_TEXT = '#f8fafc';
+const COLOR_MUTED = '#cbb8a3'; // 暖色调中性灰
+const COLOR_VALUE = '#fcd34d'; // 数值高亮(琥珀金), 用于峰值等
+
+const TITLE_TEXT = '服务器状态总览';
+
+/**
+ * 服务器状态总览画布 — 卡片式三段布局:
+ *   段一 概览: 标题 + KPI 卡片 + 历史峰值趋势条
+ *   段二 服务器详情: 各服务器地图 / 玩家 / Bots / 运行时长
+ *   段三 页脚
+ */
+export class ServerOverviewCanvas extends BaseCanvas {
+    stats: IServerOverviewStats;
+    trend: ITrendSummary;
+    mapStartedAtMap: Map<string, number | null>;
+    latencyMap: Map<string, number | null>;
+    fileName: string;
+
+    renderHeight = 0;
+
+    constructor(
+        stats: IServerOverviewStats,
+        trend: ITrendSummary,
+        fileName: string,
+        mapStartedAtMap: Map<string, number | null> = new Map(),
+        latencyMap: Map<string, number | null> = new Map(),
+    ) {
+        super();
+        this.stats = stats;
+        this.trend = trend;
+        this.fileName = fileName;
+        this.mapStartedAtMap = mapStartedAtMap;
+        this.latencyMap = latencyMap;
+    }
+
+    /** 延迟着色: 低绿 / 中琥珀 / 高红 / 无数据灰 */
+    private latencyColor(ms: number | null | undefined): string {
+        if (ms === null || ms === undefined) {
+            return COLOR_MUTED;
+        }
+        if (ms < 80) {
+            return '#4ade80';
+        }
+        if (ms < 180) {
+            return '#fbbf24';
+        }
+        return '#f87171';
+    }
+
+    private hasTrendStrip(): boolean {
+        return (
+            this.trend.series24h.length > 0 ||
+            this.trend.peak24h !== null ||
+            this.trend.peak7d !== null
+        );
+    }
+
+    /** 计算画布总高度 */
+    private computeHeight(): number {
+        let h = PAD + TITLE_H + KPI_CARD_H + SECTION_GAP;
+
+        if (this.hasTrendStrip()) {
+            h += TREND_H + SECTION_GAP;
+        }
+
+        if (this.stats.serverDetail.length > 0) {
+            h +=
+                SECTION_HEADER_H +
+                DETAIL_COL_HEADER_H +
+                this.stats.serverDetail.length * DETAIL_ROW_H +
+                SECTION_GAP;
+        }
+
+        h += FOOTER_H;
+        return h;
+    }
+
+    // ------------------------------------------------------------------
+    // 绘制辅助
+    // ------------------------------------------------------------------
+    private roundRectPath(
+        ctx: Canvas2DContext,
+        x: number,
+        y: number,
+        w: number,
+        h: number,
+        r: number,
+    ) {
+        const radius = Math.min(r, w / 2, h / 2);
+        ctx.beginPath();
+        ctx.moveTo(x + radius, y);
+        ctx.lineTo(x + w - radius, y);
+        ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+        ctx.lineTo(x + w, y + h - radius);
+        ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+        ctx.lineTo(x + radius, y + h);
+        ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+        ctx.lineTo(x, y + radius);
+        ctx.quadraticCurveTo(x, y, x + radius, y);
+        ctx.closePath();
+    }
+
+    /**
+     * 按段绘制文本(每段可独立着色/字体), 支持左对齐或右对齐整体锚定。
+     * 调用方需先设置 textBaseline。
+     */
+    private drawSegments(
+        ctx: Canvas2DContext,
+        anchorX: number,
+        y: number,
+        segments: Array<{ text: string; color: string; font: string }>,
+        align: 'left' | 'right' = 'left',
+    ) {
+        const total = segments.reduce((w, s) => {
+            ctx.font = s.font;
+            return w + ctx.measureText(s.text).width;
+        }, 0);
+
+        ctx.textAlign = 'left';
+        let cx = align === 'right' ? anchorX - total : anchorX;
+        for (const s of segments) {
+            ctx.font = s.font;
+            ctx.fillStyle = s.color;
+            ctx.fillText(s.text, cx, y);
+            cx += ctx.measureText(s.text).width;
+        }
+    }
+
+    private truncate(
+        ctx: Canvas2DContext,
+        text: string,
+        maxWidth: number,
+    ): string {
+        if (ctx.measureText(text).width <= maxWidth) {
+            return text;
+        }
+        let str = text;
+        while (str.length > 1 && ctx.measureText(str + '…').width > maxWidth) {
+            str = str.slice(0, -1);
+        }
+        return str + '…';
+    }
+
+    // ------------------------------------------------------------------
+    // 段一: 概览(标题 + KPI 卡片 + 趋势条)
+    // ------------------------------------------------------------------
+    private renderTitle(ctx: Canvas2DContext, y: number): number {
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        ctx.fillStyle = COLOR_TEXT;
+        ctx.font = buildCanvasFont(24);
+        ctx.fillText(TITLE_TEXT, PAD, y);
+
+        const labelFont = buildCanvasFont(13, 'normal');
+        const valueFont = buildCanvasFont(13);
+        this.drawSegments(
+            ctx,
+            WIDTH - PAD,
+            y + 10,
+            [
+                { text: `${this.stats.serverCount}`, color: COLOR_TEXT, font: valueFont },
+                { text: ' 服务器  ·  ', color: COLOR_MUTED, font: labelFont },
+                {
+                    text: `${this.stats.playersTotal}`,
+                    color: getCountColor(
+                        this.stats.playersTotal,
+                        this.stats.capacityTotal,
+                    ),
+                    font: valueFont,
+                },
+                { text: ' 玩家在线', color: COLOR_MUTED, font: labelFont },
+            ],
+            'right',
+        );
+        ctx.textAlign = 'left';
+
+        return y + TITLE_H;
+    }
+
+    private renderKpiCard(
+        ctx: Canvas2DContext,
+        idx: number,
+        y: number,
+        label: string,
+        value: string,
+        valueColor: string,
+        sub: string,
+    ) {
+        const x = PAD + idx * (KPI_CARD_W + KPI_GAP);
+
+        ctx.fillStyle = COLOR_CARD;
+        this.roundRectPath(ctx, x, y, KPI_CARD_W, KPI_CARD_H, 12);
+        ctx.fill();
+
+        const innerX = x + 16;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        ctx.font = buildCanvasFont(12, 'normal');
+        ctx.fillStyle = COLOR_MUTED;
+        ctx.fillText(label, innerX, y + 14);
+
+        ctx.font = buildCanvasFont(24);
+        ctx.fillStyle = valueColor;
+        ctx.fillText(this.truncate(ctx, value, KPI_CARD_W - 32), innerX, y + 36);
+
+        if (sub) {
+            ctx.font = buildCanvasFont(11, 'normal');
+            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillText(
+                this.truncate(ctx, sub, KPI_CARD_W - 32),
+                innerX,
+                y + 72,
+            );
+        }
+    }
+
+    private renderKpiRow(ctx: Canvas2DContext, y: number): number {
+        const occupancyPct = `${Math.round(this.stats.occupancyRate * 100)}%`;
+        const playersColor = getCountColor(
+            this.stats.playersTotal,
+            this.stats.capacityTotal,
+        );
+
+        this.renderKpiCard(
+            ctx,
+            0,
+            y,
+            '在线服务器',
+            `${this.stats.serverCount}`,
+            COLOR_TEXT,
+            `满 ${this.stats.fullCount} · 空 ${this.stats.emptyCount}`,
+        );
+        this.renderKpiCard(
+            ctx,
+            1,
+            y,
+            '在线玩家 / 容量',
+            `${this.stats.playersTotal}/${this.stats.capacityTotal}`,
+            playersColor,
+            `占用 ${occupancyPct}`,
+        );
+        this.renderKpiCard(
+            ctx,
+            2,
+            y,
+            'AI 单位 (Bots)',
+            `${this.stats.botsTotal}`,
+            COLOR_TEXT,
+            '',
+        );
+        this.renderKpiCard(
+            ctx,
+            3,
+            y,
+            '满员服务器',
+            `${this.stats.fullCount}`,
+            this.stats.fullCount > 0 ? COLOR_ACCENT : COLOR_TEXT,
+            `空闲 ${this.stats.emptyCount}`,
+        );
+
+        return y + KPI_CARD_H + SECTION_GAP;
+    }
+
+    private renderTrendStrip(ctx: Canvas2DContext, y: number): number {
+        if (!this.hasTrendStrip()) {
+            return y;
+        }
+
+        const cardH = TREND_H - 12;
+        ctx.fillStyle = COLOR_CARD;
+        this.roundRectPath(ctx, PAD, y, CONTENT_W, cardH, 10);
+        ctx.fill();
+
+        const innerX = PAD + 16;
+
+        // 标题行: 左侧标题 + 右侧峰值数字
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'left';
+        ctx.font = buildCanvasFont(13);
+        ctx.fillStyle = COLOR_TEXT;
+        ctx.fillText('在线趋势 · 近24小时', innerX, y + 12);
+
+        const labelFont = buildCanvasFont(12, 'normal');
+        const valueFont = buildCanvasFont(13);
+        const peakSegments: Array<{
+            text: string;
+            color: string;
+            font: string;
+        }> = [];
+        if (this.trend.peak24h !== null) {
+            peakSegments.push(
+                { text: '24h峰值 ', color: COLOR_MUTED, font: labelFont },
+                { text: `${this.trend.peak24h}人`, color: COLOR_VALUE, font: valueFont },
+            );
+        }
+        if (this.trend.peak7d !== null) {
+            if (peakSegments.length > 0) {
+                peakSegments.push({
+                    text: '   ·   ',
+                    color: COLOR_MUTED,
+                    font: labelFont,
+                });
+            }
+            peakSegments.push(
+                { text: '7日峰值 ', color: COLOR_MUTED, font: labelFont },
+                { text: `${this.trend.peak7d}人`, color: COLOR_VALUE, font: valueFont },
+            );
+        }
+        if (peakSegments.length > 0) {
+            this.drawSegments(
+                ctx,
+                WIDTH - PAD - 16,
+                y + 12,
+                peakSegments,
+                'right',
+            );
+        }
+
+        // 折线图区域
+        this.renderTrendSparkline(
+            ctx,
+            innerX,
+            y + 38,
+            CONTENT_W - 32,
+            cardH - 38 - 12,
+        );
+
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        return y + TREND_H + SECTION_GAP;
+    }
+
+    /** 在指定区域绘制近24小时在线数面积折线图 */
+    private renderTrendSparkline(
+        ctx: Canvas2DContext,
+        x: number,
+        y: number,
+        w: number,
+        h: number,
+    ) {
+        const series = this.trend.series24h;
+        const labelH = 16; // 底部小时刻度
+        const chartTop = y;
+        const baseline = y + h - labelH;
+        const chartH = baseline - chartTop;
+
+        if (series.length === 0) {
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.font = buildCanvasFont(12, 'normal');
+            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillText('暂无趋势数据', x + w / 2, chartTop + chartH / 2);
+            return;
+        }
+
+        const maxCount = Math.max(1, ...series.map((d) => d.count));
+        const n = series.length;
+        const points = series.map((d, i) => {
+            const px = n === 1 ? x + w / 2 : x + (i / (n - 1)) * w;
+            const py = baseline - (d.count / maxCount) * chartH;
+            return { x: px, y: py, count: d.count, date: d.date };
+        });
+
+        // 基线
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(x, baseline);
+        ctx.lineTo(x + w, baseline);
+        ctx.stroke();
+
+        // 面积填充
+        ctx.beginPath();
+        points.forEach((p, i) =>
+            i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y),
+        );
+        ctx.lineTo(points[n - 1].x, baseline);
+        ctx.lineTo(points[0].x, baseline);
+        ctx.closePath();
+        ctx.fillStyle = 'rgba(244, 130, 37, 0.18)';
+        ctx.fill();
+
+        // 折线
+        ctx.beginPath();
+        points.forEach((p, i) =>
+            i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y),
+        );
+        ctx.strokeStyle = COLOR_ACCENT;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        // 峰值点高亮
+        let peakIdx = 0;
+        points.forEach((p, i) => {
+            if (p.count > points[peakIdx].count) {
+                peakIdx = i;
+            }
+        });
+        const peak = points[peakIdx];
+        ctx.beginPath();
+        ctx.arc(peak.x, peak.y, 3.5, 0, Math.PI * 2);
+        ctx.fillStyle = COLOR_VALUE;
+        ctx.fill();
+
+        // 小时刻度(首 / 峰值 / 尾)
+        ctx.font = buildCanvasFont(10, 'normal');
+        ctx.fillStyle = COLOR_MUTED;
+        ctx.textBaseline = 'middle';
+        const labelY = baseline + labelH / 2 + 1;
+
+        ctx.textAlign = 'left';
+        ctx.fillText(series[0].date, x, labelY);
+
+        ctx.textAlign = 'right';
+        ctx.fillText(series[n - 1].date, x + w, labelY);
+
+        // 峰值小时(避免与首尾重叠)
+        if (peakIdx > 0 && peakIdx < n - 1) {
+            ctx.textAlign = 'center';
+            ctx.fillStyle = COLOR_VALUE;
+            ctx.fillText(peak.date, peak.x, labelY);
+        }
+
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+    }
+
+    private renderSectionHeader(
+        ctx: Canvas2DContext,
+        y: number,
+        title: string,
+    ): number {
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        ctx.fillStyle = COLOR_ACCENT;
+        ctx.fillRect(PAD, y + 2, 4, 20);
+
+        ctx.font = buildCanvasFont(16);
+        ctx.fillStyle = COLOR_TEXT;
+        ctx.fillText(title, PAD + 14, y);
+
+        return y + SECTION_HEADER_H;
+    }
+
+    // ------------------------------------------------------------------
+    // 段二: 服务器详情(地图 / 玩家 / Bots / 运行时长)
+    // ------------------------------------------------------------------
+    private renderServerDetail(ctx: Canvas2DContext, y: number): number {
+        if (this.stats.serverDetail.length === 0) {
+            return y;
+        }
+
+        y = this.renderSectionHeader(ctx, y, '服务器详情');
+
+        const nameX = PAD;
+        const mapX = PAD + 250;
+        const playersRight = PAD + 470;
+        const botsRight = PAD + 575;
+        const latencyRight = PAD + 700;
+        const durationRight = WIDTH - PAD;
+
+        // 列标题
+        ctx.textBaseline = 'middle';
+        ctx.font = buildCanvasFont(11, 'normal');
+        ctx.fillStyle = COLOR_MUTED;
+        const headMidY = y + DETAIL_COL_HEADER_H / 2;
+        ctx.textAlign = 'left';
+        ctx.fillText('服务器', nameX, headMidY);
+        ctx.fillText('地图', mapX, headMidY);
+        ctx.textAlign = 'right';
+        ctx.fillText('玩家', playersRight, headMidY);
+        ctx.fillText('Bots', botsRight, headMidY);
+        ctx.fillText('延迟', latencyRight, headMidY);
+        ctx.fillText('地图时长', durationRight, headMidY);
+
+        const bodyY = y + DETAIL_COL_HEADER_H;
+
+        this.stats.serverDetail.forEach((d, i) => {
+            const rowY = bodyY + i * DETAIL_ROW_H;
+            const midY = rowY + DETAIL_ROW_H / 2;
+
+            // 斑马纹卡片背景
+            if (i % 2 === 0) {
+                ctx.fillStyle = COLOR_CARD;
+                this.roundRectPath(
+                    ctx,
+                    PAD - 8,
+                    rowY + 2,
+                    CONTENT_W + 16,
+                    DETAIL_ROW_H - 4,
+                    6,
+                );
+                ctx.fill();
+            }
+
+            ctx.textBaseline = 'middle';
+
+            ctx.textAlign = 'left';
+            ctx.font = buildCanvasFont(13);
+            ctx.fillStyle = COLOR_TEXT;
+            ctx.fillText(
+                this.truncate(ctx, d.name, mapX - nameX - 14),
+                nameX,
+                midY,
+            );
+
+            ctx.font = buildCanvasFont(12, 'normal');
+            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillText(
+                this.truncate(ctx, d.mapName, playersRight - mapX - 60),
+                mapX,
+                midY,
+            );
+
+            ctx.textAlign = 'right';
+            ctx.font = buildCanvasFont(13);
+            ctx.fillStyle = getCountColor(d.players, d.maxPlayers);
+            ctx.fillText(`${d.players}/${d.maxPlayers}`, playersRight, midY);
+
+            ctx.fillStyle = d.bots > 0 ? '#67e8f9' : COLOR_MUTED;
+            ctx.fillText(`${d.bots}`, botsRight, midY);
+
+            // 延迟
+            const latency = this.latencyMap.get(d.serverKey);
+            const latencyText =
+                latency === null || latency === undefined
+                    ? '超时'
+                    : `${latency}ms`;
+            ctx.fillStyle = this.latencyColor(latency);
+            ctx.fillText(latencyText, latencyRight, midY);
+
+            const durationText = formatMapDuration(
+                this.mapStartedAtMap.get(d.serverKey) ?? null,
+            );
+            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillText(durationText, durationRight, midY);
+        });
+
+        ctx.textBaseline = 'top';
+        ctx.textAlign = 'left';
+        return (
+            bodyY + this.stats.serverDetail.length * DETAIL_ROW_H + SECTION_GAP
+        );
+    }
+
+    render() {
+        this.record();
+        this.renderHeight = this.computeHeight();
+
+        const canvas = createCanvas(WIDTH, this.renderHeight);
+        const ctx = canvas.getContext('2d');
+
+        // 背景
+        ctx.fillStyle = COLOR_BG;
+        ctx.fillRect(0, 0, WIDTH, this.renderHeight);
+        this.renderBgImg(ctx, WIDTH, this.renderHeight);
+
+        // 段一 概览
+        let y = PAD;
+        y = this.renderTitle(ctx, y);
+        y = this.renderKpiRow(ctx, y);
+        y = this.renderTrendStrip(ctx, y);
+
+        // 段二 服务器详情
+        y = this.renderServerDetail(ctx, y);
+
+        // 段三 页脚
+        this.renderStartY = y;
+        this.renderFooter(ctx);
+
+        return super.writeFile(canvas, this.fileName);
+    }
+}

--- a/src/commands/servers/canvas/serverOverviewCanvas.ts
+++ b/src/commands/servers/canvas/serverOverviewCanvas.ts
@@ -29,7 +29,7 @@ const FOOTER_H = 40;
 
 // 配色(与 ServersCanvas/PlayersCanvas 家族一致: #451a03 暖棕底 + OUTPUT_BG_IMG 可叠加)
 const COLOR_BG = '#451a03';
-const COLOR_CARD = 'rgba(0, 0, 0, 0.28)'; // 半透明深色面板, 叠在底色或背景图上均协调
+const COLOR_CARD = 'rgba(0, 0, 0, 0.5)'; // 半透明深色面板, 叠在底色或背景图上均协调
 const COLOR_ACCENT = '#f48225';
 const COLOR_TEXT = '#f8fafc';
 const COLOR_MUTED = '#cbb8a3'; // 暖色调中性灰
@@ -173,6 +173,35 @@ export class ServerOverviewCanvas extends BaseCanvas {
             str = str.slice(0, -1);
         }
         return str + '…';
+    }
+
+    /**
+     * 在 maxWidth 内绘制完整文本; 若放不下则从 startSize 递减到 minSize 寻找合适字号,
+     * 仍放不下则以 minSize 绘制(不截断, 禁止换行)。
+     */
+    private drawFitText(
+        ctx: Canvas2DContext,
+        text: string,
+        x: number,
+        y: number,
+        maxWidth: number,
+        startSize: number,
+        minSize: number,
+        color: string,
+        align: 'left' | 'right' = 'left',
+    ) {
+        ctx.textAlign = align;
+        for (let size = startSize; size >= minSize; size--) {
+            ctx.font = buildCanvasFont(size);
+            if (ctx.measureText(text).width <= maxWidth) {
+                ctx.fillStyle = color;
+                ctx.fillText(text, x, y);
+                return;
+            }
+        }
+        ctx.font = buildCanvasFont(minSize);
+        ctx.fillStyle = color;
+        ctx.fillText(text, x, y);
     }
 
     // ------------------------------------------------------------------
@@ -495,10 +524,10 @@ export class ServerOverviewCanvas extends BaseCanvas {
         const latencyRight = PAD + 700;
         const durationRight = WIDTH - PAD;
 
-        // 列标题
+        // 列标题 (醒目 + 具有标识性)
         ctx.textBaseline = 'middle';
-        ctx.font = buildCanvasFont(11, 'normal');
-        ctx.fillStyle = COLOR_MUTED;
+        ctx.font = buildCanvasFont(11);
+        ctx.fillStyle = COLOR_VALUE;
         const headMidY = y + DETAIL_COL_HEADER_H / 2;
         ctx.textAlign = 'left';
         ctx.fillText('服务器', nameX, headMidY);
@@ -531,17 +560,21 @@ export class ServerOverviewCanvas extends BaseCanvas {
 
             ctx.textBaseline = 'middle';
 
-            ctx.textAlign = 'left';
-            ctx.font = buildCanvasFont(13);
-            ctx.fillStyle = COLOR_TEXT;
-            ctx.fillText(
-                this.truncate(ctx, d.name, mapX - nameX - 14),
+            // 服务器名称保持全名, 字号自适应(禁止截断/换行)
+            this.drawFitText(
+                ctx,
+                d.name,
                 nameX,
                 midY,
+                mapX - nameX - 14,
+                13,
+                9,
+                COLOR_TEXT,
+                'left',
             );
 
             ctx.font = buildCanvasFont(12, 'normal');
-            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillStyle = COLOR_ACCENT;
             ctx.fillText(
                 this.truncate(ctx, d.mapName, playersRight - mapX - 60),
                 mapX,
@@ -568,7 +601,7 @@ export class ServerOverviewCanvas extends BaseCanvas {
             const durationText = formatMapDuration(
                 this.mapStartedAtMap.get(d.serverKey) ?? null,
             );
-            ctx.fillStyle = COLOR_MUTED;
+            ctx.fillStyle = '#67e8f9';
             ctx.fillText(durationText, durationRight, midY);
         });
 

--- a/src/commands/servers/register.ts
+++ b/src/commands/servers/register.ts
@@ -6,6 +6,7 @@ import {
     printMapDetailPng,
     printPlayersPng,
     printServerListPng,
+    printServerOverviewPng,
     printUserInServerListPng,
 } from './utils/canvas';
 import {
@@ -13,6 +14,7 @@ import {
     MAP_DETAIL_OUTPUT_FILE,
     PLAYERS_OUTPUT_FILE,
     SERVERS_OUTPUT_FILE,
+    SERVER_OVERVIEW_OUTPUT_FILE,
     WHEREIS_OUTPUT_FILE,
 } from './types/constants';
 import {
@@ -21,6 +23,8 @@ import {
     findMapByQuery,
     getServersForMap,
 } from './utils/utils';
+import { aggregateOverview, readTrendSummary } from './utils/overview';
+import { pingServers } from './utils/ping';
 import {
     printChartPng,
     printHoursChartPng,
@@ -515,3 +519,59 @@ export const ServerAnalyticsCommandRegister: IRegister = {
         AnalysticsServerTask.start(env);
     },
 };
+
+// ============================================================================
+// OVERVIEW COMMAND - 服务器状态总览(实时快照 + 历史趋势 一图概览)
+// ============================================================================
+export const ServerOverviewCommandRegister = createServerCommand(
+    {
+        name: 'overview',
+        alias: 'o',
+        hint: ['查询服务器状态总览(规模/占用/各服务器地图·Bots·运行时长/离线): #overview'],
+        description:
+            '查询服务器状态总览(实时规模、占用率、各服务器地图·Bots·运行时长、历史峰值、近期离线).[15s CD]',
+        timesInterval: 15,
+    },
+    async (ctx) => {
+        await executeSharedGroupCommand(ctx, {
+            command: 'overview',
+            params: {},
+            cdMs: 5000,
+            apiCall: async (): Promise<ApiResult> => {
+                const serverList = await queryAllServers(
+                    ctx.env.SERVERS_MATCH_REGEX,
+                );
+                const stats = aggregateOverview(serverList);
+                const trend = readTrendSummary();
+                const latencyMap = await pingServers(serverList);
+                printServerOverviewPng(
+                    stats,
+                    trend,
+                    serverList,
+                    latencyMap,
+                    SERVER_OVERVIEW_OUTPUT_FILE,
+                );
+                return {
+                    serverList,
+                    outputFile: SERVER_OVERVIEW_OUTPUT_FILE,
+                };
+            },
+            buildReply: async (apiResult) =>
+                generateServerReply(
+                    ctx,
+                    apiResult.serverList,
+                    apiResult.outputFile,
+                ),
+            firstRequesterMessage:
+                '正在生成状态总览(含服务器延迟检测), 请稍后...',
+            pendingMessage: '状态总览生成中，请稍后...',
+            failureMessage: '生成状态总览失败，请稍后重试',
+        });
+    },
+    async (env: GlobalEnv): Promise<void> => {
+        logger.info('ServerOverviewCommandRegister::init()');
+        // 历史峰值趋势依赖以下任务持续写入(均为幂等启动)
+        AnalysticsTask.start(env);
+        AnalysticsHoursTask.start(env);
+    },
+);

--- a/src/commands/servers/types/constants.ts
+++ b/src/commands/servers/types/constants.ts
@@ -18,3 +18,5 @@ export const PLAYERS_OUTPUT_FILE = 'players.png';
 export const ANALYSIS_SERVER_OUTPUT_FILE = 'analysis_server.png';
 
 export const ANALYSIS_SERVER_DATA_FILE = 'analysis_server.json';
+
+export const SERVER_OVERVIEW_OUTPUT_FILE = 'server_overview.png';

--- a/src/commands/servers/types/types.ts
+++ b/src/commands/servers/types/types.ts
@@ -74,3 +74,30 @@ export interface IMapImageConfigItem {
 export interface IMapImageConfigFile {
     images: IMapImageConfigItem[];
 }
+
+export interface ITrendSummary {
+    peak24h: number | null; // analysis_hours.json 最大值
+    peak7d: number | null; // analysis.json 最大值
+    latest: number | null; // 最近一条记录
+    series24h: IAnalysisData[]; // 近24小时逐时在线数序列(用于绘制趋势折线)
+}
+
+export interface IServerDetailItem {
+    name: string;
+    mapName: string;
+    players: number;
+    maxPlayers: number;
+    bots: number;
+    serverKey: string; // `${address}:${port}`, 用于查询地图运行时长
+}
+
+export interface IServerOverviewStats {
+    serverCount: number;
+    playersTotal: number;
+    capacityTotal: number;
+    occupancyRate: number; // 0-1
+    botsTotal: number;
+    fullCount: number; // current_players >= max_players
+    emptyCount: number; // current_players === 0
+    serverDetail: IServerDetailItem[]; // 各服务器详情, 按玩家数降序
+}

--- a/src/commands/servers/utils/canvas.ts
+++ b/src/commands/servers/utils/canvas.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import {
     HistoricalServerItem,
     IMapDataItem,
+    IServerOverviewStats,
+    ITrendSummary,
     IUserMatchedServerItem,
     OnlineServerItem,
 } from '../types/types';
@@ -11,6 +13,7 @@ import { PlayersCanvas } from '../canvas/playersCanvas';
 import { WhereisCanvas } from '../canvas/whereisCanvas';
 import { MapsCanvas } from '../canvas/mapsCanvas';
 import { MapDetailCanvas } from '../canvas/mapDetailCanvas';
+import { ServerOverviewCanvas } from '../canvas/serverOverviewCanvas';
 
 const OUTPUT_FOLDER = 'out';
 
@@ -117,6 +120,36 @@ export const printMapPng = (
 
     const mapStartedAtMap = buildMapStartedAtMap(serverList);
     const outputPath = new MapsCanvas(serverList, mapData, fileName, mapStartedAtMap).render();
+
+    return outputPath;
+};
+
+/**
+ * Print server overview(status report) output png
+ * @param stats 实时快照聚合统计
+ * @param trend 历史趋势峰值摘要
+ * @param historicalServers 近期离线服务器
+ * @param fileName 输出文件名
+ */
+export const printServerOverviewPng = (
+    stats: IServerOverviewStats,
+    trend: ITrendSummary,
+    serverList: OnlineServerItem[],
+    latencyMap: Map<string, number | null>,
+    fileName: string,
+): string => {
+    if (!fs.existsSync(OUTPUT_FOLDER)) {
+        fs.mkdirSync(OUTPUT_FOLDER);
+    }
+
+    const mapStartedAtMap = buildMapStartedAtMap(serverList);
+    const outputPath = new ServerOverviewCanvas(
+        stats,
+        trend,
+        fileName,
+        mapStartedAtMap,
+        latencyMap,
+    ).render();
 
     return outputPath;
 };

--- a/src/commands/servers/utils/overview.test.ts
+++ b/src/commands/servers/utils/overview.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import { OnlineServerItem } from '../types/types';
+import { aggregateOverview, readTrendSummary } from './overview';
+
+vi.mock('fs', async () => {
+    const actual = await vi.importActual<typeof import('fs')>('fs');
+    return {
+        ...actual,
+        existsSync: vi.fn(),
+        readFileSync: vi.fn(),
+    };
+});
+
+const makeServer = (
+    overrides: Partial<OnlineServerItem> = {},
+): OnlineServerItem => ({
+    name: 'server',
+    address: '1.1.1.1',
+    port: 1000,
+    map_id: 'media/packages/x/maps/map1',
+    map_name: '',
+    bots: 0,
+    country: 'China',
+    current_players: 0,
+    timeStamp: 0,
+    version: '1.0',
+    dedicated: true,
+    mod: 1,
+    comment: '',
+    url: '',
+    max_players: 20,
+    mode: 'Coop',
+    realm: '',
+    playersCount: 0,
+    ...overrides,
+});
+
+describe('aggregateOverview', () => {
+    it('computes core KPI from snapshot', () => {
+        const servers = [
+            makeServer({ current_players: 20, max_players: 20, bots: 10 }), // 满员
+            makeServer({ current_players: 5, max_players: 20, bots: 3 }),
+            makeServer({ current_players: 0, max_players: 20, bots: 0 }), // 空
+        ];
+
+        const stats = aggregateOverview(servers);
+
+        expect(stats.serverCount).toBe(3);
+        expect(stats.playersTotal).toBe(25);
+        expect(stats.capacityTotal).toBe(60);
+        expect(stats.botsTotal).toBe(13);
+        expect(stats.fullCount).toBe(1);
+        expect(stats.emptyCount).toBe(1);
+        expect(stats.occupancyRate).toBeCloseTo(25 / 60);
+    });
+
+    it('handles empty server list without dividing by zero', () => {
+        const stats = aggregateOverview([]);
+        expect(stats.serverCount).toBe(0);
+        expect(stats.occupancyRate).toBe(0);
+        expect(stats.serverDetail).toEqual([]);
+    });
+
+    it('builds per-server detail (map/bots/key) sorted by players desc', () => {
+        const servers = [
+            makeServer({
+                name: 'Low',
+                address: '2.2.2.2',
+                port: 2000,
+                map_id: 'media/packages/x/maps/mapB',
+                bots: 4,
+                current_players: 3,
+            }),
+            makeServer({
+                name: 'High',
+                address: '3.3.3.3',
+                port: 3000,
+                map_id: 'media/packages/x/maps/mapA',
+                bots: 9,
+                current_players: 15,
+            }),
+        ];
+
+        const stats = aggregateOverview(servers);
+
+        expect(stats.serverDetail.map((d) => d.name)).toEqual(['High', 'Low']);
+        expect(stats.serverDetail[0]).toMatchObject({
+            name: 'High',
+            mapName: 'mapA',
+            players: 15,
+            maxPlayers: 20,
+            bots: 9,
+            serverKey: '3.3.3.3:3000',
+        });
+    });
+});
+
+describe('readTrendSummary', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns null fields when data files are missing', () => {
+        (fs.existsSync as any).mockReturnValue(false);
+
+        const trend = readTrendSummary();
+
+        expect(trend).toEqual({
+            peak24h: null,
+            peak7d: null,
+            latest: null,
+            series24h: [],
+        });
+    });
+
+    it('returns peaks and latest when files exist', () => {
+        (fs.existsSync as any).mockReturnValue(true);
+        (fs.readFileSync as any).mockImplementation((p: any) => {
+            const file = String(p);
+            if (file.includes('analysis_hours.json')) {
+                return JSON.stringify([
+                    { date: '10:00', count: 30 },
+                    { date: '11:00', count: 55 },
+                    { date: '12:00', count: 42 },
+                ]);
+            }
+            if (file.includes('analysis.json')) {
+                return JSON.stringify([
+                    { date: '6/1', count: 80 },
+                    { date: '6/2', count: 120 },
+                ]);
+            }
+            return '[]';
+        });
+
+        const trend = readTrendSummary();
+
+        expect(trend.peak24h).toBe(55);
+        expect(trend.peak7d).toBe(120);
+        expect(trend.latest).toBe(42); // analysis_hours 最后一条
+        expect(trend.series24h).toHaveLength(3); // 近24h逐时序列
+        expect(trend.series24h[1]).toEqual({ date: '11:00', count: 55 });
+    });
+});

--- a/src/commands/servers/utils/overview.ts
+++ b/src/commands/servers/utils/overview.ts
@@ -1,0 +1,126 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from '../../../utils/logger';
+import {
+    IAnalysisData,
+    IServerDetailItem,
+    IServerOverviewStats,
+    ITrendSummary,
+    OnlineServerItem,
+} from '../types/types';
+import {
+    ANALYSIS_DATA_FILE,
+    ANALYSIS_HOURS_DATA_FILE,
+    OUTPUT_FOLDER,
+} from '../types/constants';
+import {
+    countServersMaxPlayers,
+    countTotalPlayers,
+    getMapShortName,
+} from './utils';
+
+/**
+ * 聚合实时快照统计信息
+ * @param serverList 当前匹配的服务器列表
+ * @returns 服务器概览统计
+ */
+export const aggregateOverview = (
+    serverList: OnlineServerItem[],
+): IServerOverviewStats => {
+    const serverCount = serverList.length;
+    const playersTotal = countTotalPlayers(serverList);
+    const capacityTotal = countServersMaxPlayers(serverList);
+    const occupancyRate = capacityTotal > 0 ? playersTotal / capacityTotal : 0;
+
+    let botsTotal = 0;
+    let fullCount = 0;
+    let emptyCount = 0;
+
+    serverList.forEach((s) => {
+        botsTotal += s.bots ?? 0;
+        if (s.current_players >= s.max_players && s.max_players > 0) {
+            fullCount += 1;
+        }
+        if (s.current_players === 0) {
+            emptyCount += 1;
+        }
+    });
+
+    const serverDetail: IServerDetailItem[] = serverList
+        .map((s) => ({
+            name: s.name,
+            mapName: getMapShortName(s.map_id),
+            players: s.current_players,
+            maxPlayers: s.max_players,
+            bots: s.bots ?? 0,
+            serverKey: `${s.address}:${s.port}`,
+        }))
+        .sort((a, b) => b.players - a.players);
+
+    return {
+        serverCount,
+        playersTotal,
+        capacityTotal,
+        occupancyRate,
+        botsTotal,
+        fullCount,
+        emptyCount,
+        serverDetail,
+    };
+};
+
+/**
+ * 读取趋势数据文件(峰值统计), 文件缺失或解析失败时返回 null
+ * @param fileName 输出目录下的数据文件名
+ * @returns 解析后的统计数组, 失败为 null
+ */
+const readAnalysisFile = (fileName: string): IAnalysisData[] | null => {
+    const filePath = path.join(process.cwd(), OUTPUT_FOLDER, `./${fileName}`);
+
+    if (!fs.existsSync(filePath)) {
+        return null;
+    }
+
+    try {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const parsed = JSON.parse(content) as IAnalysisData[];
+        if (!Array.isArray(parsed)) {
+            return null;
+        }
+        return parsed;
+    } catch (e) {
+        logger.error('> readAnalysisFile error', fileName);
+        logger.error(e);
+        return null;
+    }
+};
+
+const maxCount = (data: IAnalysisData[] | null): number | null => {
+    if (!data || data.length === 0) {
+        return null;
+    }
+    return data.reduce((acc, cur) => Math.max(acc, cur.count), 0);
+};
+
+const latestCount = (data: IAnalysisData[] | null): number | null => {
+    if (!data || data.length === 0) {
+        return null;
+    }
+    return data[data.length - 1].count;
+};
+
+/**
+ * 汇总历史趋势峰值(24小时 / 7日 / 最近值)
+ * @returns 趋势摘要, 数据缺失时对应字段为 null
+ */
+export const readTrendSummary = (): ITrendSummary => {
+    const hoursData = readAnalysisFile(ANALYSIS_HOURS_DATA_FILE);
+    const daysData = readAnalysisFile(ANALYSIS_DATA_FILE);
+
+    return {
+        peak24h: maxCount(hoursData),
+        peak7d: maxCount(daysData),
+        latest: latestCount(hoursData) ?? latestCount(daysData),
+        series24h: hoursData ?? [],
+    };
+};

--- a/src/commands/servers/utils/ping.ts
+++ b/src/commands/servers/utils/ping.ts
@@ -1,0 +1,92 @@
+import { execFile } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
+import { promisify } from 'node:util';
+import { logger } from '../../../utils/logger';
+import { OnlineServerItem } from '../types/types';
+
+// 逻辑参考 src/commands/check/utils.ts 的 ICMP ping 探测
+const PING_TIMEOUT_MS = 3000;
+const execFileAsync = promisify(execFile);
+
+const getPingArgs = (host: string, timeoutMs: number): string[] => {
+    switch (process.platform) {
+        case 'win32':
+            return ['-n', '1', '-w', String(timeoutMs), host];
+        case 'darwin':
+        default:
+            return ['-c', '1', host];
+    }
+};
+
+const parsePingLatency = (stdout: string): number | null => {
+    const normalized = stdout.replace(/\s+/g, ' ');
+    const patterns = [
+        /time[=<]\s*([\d.]+)\s*ms/i,
+        /time\s+([\d.]+)\s*ms/i,
+        /时间[=<]\s*([\d.]+)\s*ms/i,
+        /时间\s*[\=<]\s*([\d.]+)/i,
+        /平均\s*=\s*([\d.]+)\s*ms/i,
+        /Average\s*=\s*([\d.]+)\s*ms/i,
+    ];
+
+    for (const pattern of patterns) {
+        const match = normalized.match(pattern);
+        if (!match) {
+            continue;
+        }
+        const value = Number(match[1]);
+        if (Number.isFinite(value)) {
+            return Math.round(value);
+        }
+    }
+
+    if (
+        /time[=<]\s*1\s*ms/i.test(normalized) ||
+        /时间[=<]\s*1\s*ms/i.test(normalized)
+    ) {
+        return 1;
+    }
+
+    return null;
+};
+
+/**
+ * ICMP ping 单个主机, 返回延迟毫秒数; 失败/超时返回 null
+ * @param host 主机地址
+ * @param timeoutMs 超时(毫秒)
+ */
+export const pingHost = async (
+    host: string,
+    timeoutMs = PING_TIMEOUT_MS,
+): Promise<number | null> => {
+    const startedAt = performance.now();
+    try {
+        const { stdout } = await execFileAsync(
+            'ping',
+            getPingArgs(host, timeoutMs),
+            { timeout: timeoutMs + 1000, windowsHide: true },
+        );
+        const parsed = parsePingLatency(stdout);
+        return parsed ?? Math.round(performance.now() - startedAt);
+    } catch (error) {
+        logger.error(`[overview] ping failed: ${host}`, error);
+        return null;
+    }
+};
+
+/**
+ * 并发 ping 服务器列表, 返回 `${address}:${port}` -> 延迟(ms, 失败为 null) 映射
+ * @param serverList 服务器列表
+ */
+export const pingServers = async (
+    serverList: OnlineServerItem[],
+): Promise<Map<string, number | null>> => {
+    const entries = await Promise.all(
+        serverList.map(async (s) => {
+            const key = `${s.address}:${s.port}`;
+            const latency = await pingHost(s.address);
+            return [key, latency] as const;
+        }),
+    );
+    return new Map(entries);
+};


### PR DESCRIPTION
… with KPIs, trend, and ping

Add `overview` command and its alias `o` for generating a comprehensive server status image. The overview includes:
- Section 1: Title, four KPI cards (online servers, players/capacity/occupancy, total bots, full servers) and a 24h trend chart with peak annotations.
- Section 2: Per-server details (name, map, players with color coding, bots, ping latency with color thresholds, map duration) sorted by players descending.
- Section 3: Footer with render time and timestamp.

Implemented supporting utilities:
- `utils/overview.ts` – aggregates real-time server snapshot into `IServerOverviewStats` and reads historical trend data from analysis files.
- `utils/ping.ts` – concurrent ICMP ping with fallback timeout, cross-platform argument handling.
- `canvas/serverOverviewCanvas.ts` – full canvas rendering with consistent color scheme (`#451a03` background, overlay support).

New command init also idempotently starts `AnalysticsTask` and `AnalysticsHoursTask` to ensure trend data availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new server overview command (`overview` / `o`) that generates a stacked image with KPIs, a per-server detail table (players, bots, capacity, latency, runtime) and optional 24h trend sparklines with peak indicators.
  * Outputs an image file and uses a 15s cooldown.

* **Documentation**
  * Added user-facing docs describing command usage, aliases, environment settings, data sources, and cooldown.

* **Tests**
  * Added tests for aggregation and trend-summary parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->