### PR TITLE
fix(servers): simplify analytics PNG output by using constant directly

### DIFF
--- a/src/commands/servers/register.ts
+++ b/src/commands/servers/register.ts
@@ -441,11 +441,11 @@ export const AnalyticsCommandRegister: IRegister = {
             cdMs: 5000,
             apiCall: async (): Promise<ApiResult> => {
                 const view = buildAnalyticsView();
-                const outputFile = printAnalyticsPng(
+                printAnalyticsPng(
                     view,
                     ANALYTICS_OVERVIEW_OUTPUT_FILE,
                 );
-                return { serverList: [], outputFile };
+                return { serverList: [], outputFile: ANALYTICS_OVERVIEW_OUTPUT_FILE };
             },
             buildReply: async (apiResult) =>
                 `[CQ:image,file=${getStaticHttpPath(
@@ -485,11 +485,11 @@ export const ServerAnalyticsCommandRegister: IRegister = {
             cdMs: 5000,
             apiCall: async (): Promise<ApiResult> => {
                 const view = buildAnalyticsView();
-                const outputFile = printAnalyticsPng(
+                printAnalyticsPng(
                     view,
                     ANALYTICS_OVERVIEW_OUTPUT_FILE,
                 );
-                return { serverList: [], outputFile };
+                return { serverList: [], outputFile: ANALYTICS_OVERVIEW_OUTPUT_FILE };
             },
             buildReply: async (apiResult) =>
                 `[CQ:image,file=${getStaticHttpPath(


### PR DESCRIPTION
The `printAnalyticsPng` function is now called solely for its side effect; the returned file path is no longer stored. The `outputFile` field in the API result is set directly to `ANALYTICS_OVERVIEW_OUTPUT_FILE` to ensure consistency across the two command registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal analytics command handling to streamline code execution and enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->