### PR TITLE
feat(skills): add agent skills lockfile and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ test-data/
 /.agent-shell/
 .codegraph/
 .cursor/
+.agents/
+.augment/
+.factory/
+.goose/
+.trae/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "skills": {
+    "cavecrew": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/cavecrew/SKILL.md",
+      "computedHash": "505d836228d1c5e14834ff5d62aad72390c7d27f79c6aa7f9a7a55ed6606d6a2"
+    },
+    "caveman": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "1902fa0b569912d0c05736d8d98a72097d9b82719aac88c0c1d03bb546f9176d"
+    },
+    "caveman-commit": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-commit/SKILL.md",
+      "computedHash": "790a4eeace0be35c6691faf923518ba5bd50f1f1305d1101d09dd4971be94e00"
+    },
+    "caveman-compress": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-compress/SKILL.md",
+      "computedHash": "1e9b3e2bf68b75dc0252c4328c8514bea79d4d8f7d7259da616ba7d12cad6865"
+    },
+    "caveman-help": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-help/SKILL.md",
+      "computedHash": "dd85267e76baad76995157e7b9f762dfa557cd58951ee92af0c283f48aa26537"
+    },
+    "caveman-review": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-review/SKILL.md",
+      "computedHash": "fb7214a1c5793bae6ba8b1be4329e2e6f40dbec6dd911dfb335ad29f09c316a1"
+    },
+    "caveman-stats": {
+      "source": "JuliusBrussee/caveman",
+      "sourceType": "github",
+      "skillPath": "skills/caveman-stats/SKILL.md",
+      "computedHash": "47ce2de3d6cb39a75047b5c962e4eb3da15594e7397c94103e9a104d42626553"
+    }
+  }
+}

--- a/src/commands/tdoll/utils/commandHelper.ts
+++ b/src/commands/tdoll/utils/commandHelper.ts
@@ -15,7 +15,7 @@ import {
 import { ITDollDataItem } from '../types/types';
 
 /** 多结果时的可操作提示尾行 */
-export const MULTI_RESULT_TAIL = '回复 #td <完整名称> 查看详情与皮肤';
+export const MULTI_RESULT_TAIL = '输入 #ts <武器ID> 查看详情与皮肤';
 
 /** 单结果时的可复制信息尾行 */
 export const buildSingleResultTail = (tdoll: ITDollDataItem): string =>


### PR DESCRIPTION
- Add skills-lock.json for caveman-related AI agent skill definitions
- Add .agents, .augment, .factory, .goose, .trae to .gitignore
- Update tdoll command helper to use correct `#ts <武器ID>` syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the TDoll multi-result prompt to point users to weapon ID input for viewing details and skins.
* **Chores**
  * Expanded ignored files to include several local tool directories.
  * Added a versioned lock file for available skills to keep the configured set consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->