### PR TITLE
feat(tdoll): add support for retrieving raw skin image by skin ID

### DIFF
--- a/src/commands/tdoll/register.ts
+++ b/src/commands/tdoll/register.ts
@@ -4,9 +4,10 @@ import { TDollSkinSvc } from './services/tdollskin.service';
 import { logger } from '../../utils/logger';
 import { TDOLL_SKIN_NOT_FOUND_MSG } from './types/constants';
 import { buildUserScopedPngName } from '../../utils/cmdreq';
-import { cqImageFile } from '../../utils/cqCode';
+import { cqImageFile, cqImageUrl } from '../../utils/cqCode';
 import { CommandHelper } from './utils/commandHelper';
 import { printTDollDetailPng } from './utils/utils';
+import { resolveSkinImageUrl } from './canvas/assets';
 
 /**
  * 注入两个数据源的文件路径。环境变量名(TDOLL_DATA_FILE / TDOLL_SKIN_DATA_FILE)
@@ -61,45 +62,91 @@ const createTDollCommand = (name: string, alias: string): IRegister => {
 export const TDollCommandRegister = createTDollCommand('tdoll', 'td');
 
 const createTDollSkinCommand = (name: string, alias: string): IRegister => {
+    /**
+     * 单武器全部皮肤网格图(原有行为)。
+     */
+    const execSkinGrid = async (ctx: any, weaponId: string) => {
+        const start = Date.now();
+        const [tdollData, tdollSkinData] = await Promise.all([
+            TDollSvc.getData(),
+            TDollSkinSvc.getData(),
+        ]);
+
+        logger.info('Fetched tdoll & tdollSkinData', {
+            duration: Date.now() - start,
+            tdollCount: tdollData.length,
+            skinCount: Object.keys(tdollSkinData).length,
+        });
+
+        if (!(weaponId in tdollSkinData)) {
+            await ctx.reply(TDOLL_SKIN_NOT_FOUND_MSG);
+            return;
+        }
+
+        await ctx.reply('正在查询数据并生成, 请稍候...');
+
+        const fileName = buildUserScopedPngName('tdoll_skin', ctx.event);
+        await printTDollDetailPng(weaponId, tdollData, tdollSkinData, fileName);
+
+        await ctx.reply(cqImageFile(ctx.env, fileName));
+    };
+
+    /**
+     * 指定皮肤原图(武器编号 + 皮肤ID)。直接发远端 gfwiki 原图,不落地 out/、不走 canvas。
+     */
+    const execSkinRawImage = async (
+        ctx: any,
+        weaponId: string,
+        skinId: string
+    ) => {
+        const tdollSkinData = await TDollSkinSvc.getData();
+
+        const skins = tdollSkinData[weaponId];
+        if (!skins) {
+            await ctx.reply(TDOLL_SKIN_NOT_FOUND_MSG);
+            return;
+        }
+
+        const skin = skins.find((s) => s.value === skinId);
+        if (!skin) {
+            const availableIds = skins
+                .map((s) => s.value)
+                .filter(Boolean)
+                .join(', ');
+            await ctx.reply(
+                `未找到武器 ${weaponId} 下皮肤ID为 ${skinId} 的皮肤。\n可用皮肤ID: ${availableIds || '无'}`
+            );
+            return;
+        }
+
+        const pic = skin.image?.pic;
+        if (!pic) {
+            await ctx.reply(`该皮肤(${skin.title})暂无原图数据`);
+            return;
+        }
+
+        const url = resolveSkinImageUrl(pic);
+        const tail = `No.${weaponId} ${skin.title}(皮肤ID:${skin.value}) | 全部皮肤: #${alias} ${weaponId}`;
+
+        await ctx.reply(`${cqImageUrl(url)}\n${tail}`);
+    };
+
     const exec = async (ctx: any) => {
         try {
-            if (!(await CommandHelper.validateParams(ctx, 1))) {
-                await ctx.reply(`需要1个参数, 示例: #${name} 2`);
+            if (!(await CommandHelper.validateParams(ctx, 1, 2))) {
+                await ctx.reply(
+                    `参数不正确, 示例:\n#${name} 2 (查询该武器全部皮肤)\n#${name} 2 0 (查询指定皮肤原图)`
+                );
                 return;
             }
 
-            const start = Date.now();
-            const [tdollData, tdollSkinData] = await Promise.all([
-                TDollSvc.getData(),
-                TDollSkinSvc.getData(),
-            ]);
+            const [weaponId, skinId] = CommandHelper.getQueryParams(ctx.params);
 
-            logger.info('Fetched tdoll & tdollSkinData', {
-                duration: Date.now() - start,
-                tdollCount: tdollData.length,
-                skinCount: Object.keys(tdollSkinData).length,
-            });
-
-            const [query] = CommandHelper.getQueryParams(ctx.params);
-            
-            if (!(query in tdollSkinData)) {
-                await ctx.reply(TDOLL_SKIN_NOT_FOUND_MSG);
-                return;
+            if (skinId === undefined) {
+                await execSkinGrid(ctx, weaponId);
+            } else {
+                await execSkinRawImage(ctx, weaponId, skinId);
             }
-
-            await ctx.reply('正在查询数据并生成, 请稍候...');
-
-            const fileName = buildUserScopedPngName('tdoll_skin', ctx.event);
-            await printTDollDetailPng(
-                query,
-                tdollData,
-                tdollSkinData,
-                fileName
-            );
-
-            const replyText = cqImageFile(ctx.env, fileName);
-
-            await ctx.reply(replyText);
         } catch (error) {
             await CommandHelper.handleError(ctx, error, name);
             logger.error(`${name} command failed`, { error, ctx });
@@ -109,8 +156,12 @@ const createTDollSkinCommand = (name: string, alias: string): IRegister => {
     return {
         name,
         alias,
-        description: '根据武器编号查询皮肤数据, 需要输入一个编号参数.[10s CD]',
-        hint: [`查询指定 ID 武器皮肤数据: #${name} 2`],
+        description:
+            '根据武器编号查询皮肤数据; 追加皮肤ID可查看该皮肤原图.[10s CD]',
+        hint: [
+            `查询指定 ID 武器皮肤数据: #${name} 2`,
+            `查询指定皮肤原图: #${name} 2 0`,
+        ],
         timesInterval: 10,
         isAdmin: false,
         init: initTDollServices,


### PR DESCRIPTION
The tdoll skin command now accepts two query parameters: weapon ID and optional skin ID. When only weapon ID is provided, the existing grid image is generated. When a skin ID is given, the command fetches the raw GFWiki image directly without rendering or saving to disk.

- Split original `exec` into `execSkinGrid` and `execSkinRawImage`
- Added import for `cqImageUrl` and `resolveSkinImageUrl`
- Updated command parsing to handle new parameter format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the `tdollskin` command to accept an optional skin ID.
  * Without a skin ID, displays the full skin grid for a weapon.
  * With a skin ID, retrieves and sends the corresponding skin image directly.
  * Updated command guidance to explain the new usage options.

* **Bug Fixes**
  * Added validation for weapon and skin IDs before displaying images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->