### PR TITLE
refactor(tdoll): cache skin raw images by content instead of per user

### DIFF
--- a/src/commands/tdoll/register.test.ts
+++ b/src/commands/tdoll/register.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GlobalEnv, MessageEvent, MsgExecCtx } from '../../types';
+
+// Mock fs so the success path does not touch disk; capture calls instead.
+// 默认全部走"缓存未命中"路径: access 拒绝, 写入相关均成功。
+vi.mock('node:fs/promises', () => ({
+    access: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { access, mkdir, rename, writeFile } from 'node:fs/promises';
+import { TDollSkinSvc } from './services/tdollskin.service';
+import {
+    SKIN_RAW_IMAGE_LOADING_MSG,
+    SKIN_RAW_IMAGE_TIMEOUT_MSG,
+} from './types/constants';
+import { TDollSkinCommandRegister } from './register';
+
+/**
+ * Build a minimal MsgExecCtx whose params encode `tdollskin <args...>`.
+ * env/event are cast from partials — cqImageFile only reads HOSTNAME/PORT,
+ * buildUserScopedPngName only reads group_id/user_id.
+ */
+const buildCtx = (args: string[]): { ctx: MsgExecCtx; replies: string[] } => {
+    const replies: string[] = [];
+    const params = new Map<string, boolean>();
+    for (const a of args) params.set(a, true);
+
+    const ctx = {
+        msg: `#ts ${args.join(' ')}`,
+        params,
+        env: { HOSTNAME: 'localhost', PORT: 3000 } as unknown as GlobalEnv,
+        event: {
+            group_id: 123,
+            user_id: 456,
+        } as unknown as MessageEvent,
+        reply: async (m: string) => {
+            replies.push(m);
+        },
+    } as unknown as MsgExecCtx;
+
+    return { ctx, replies };
+};
+
+const seedSkinData = (pic = '/images/7/7f/Pic_Test_HD.png') => {
+    vi.spyOn(TDollSkinSvc, 'getData').mockResolvedValue({
+        '2': [
+            {
+                index: 0,
+                title: '测试皮肤',
+                value: '0',
+                image: { anime: '', line: '', name: '', pic, pic_d: '', pic_d_h: '', pic_h: '' },
+            },
+        ],
+    });
+};
+
+/** 重置 fs 各 mock 到"缓存未命中 + 写入成功"默认状态。 */
+const resetFsMocks = () => {
+    vi.mocked(access)
+        .mockReset()
+        .mockRejectedValue(
+            Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+        );
+    vi.mocked(mkdir).mockReset().mockResolvedValue(undefined);
+    vi.mocked(writeFile).mockReset().mockResolvedValue(undefined);
+    vi.mocked(rename).mockReset().mockResolvedValue(undefined);
+};
+
+describe('tdollskin <weaponId> <skinId> — raw image loading flow', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        // vi.mock factory fns are not touched by restoreAllMocks — reset explicitly.
+        resetFsMocks();
+    });
+
+    it('sends the loading hint before the image on success', async () => {
+        seedSkinData();
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+                    status: 200,
+                }),
+            );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { ctx, replies } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        // Loading hint first, then the local PNG CQ image with tail.
+        expect(replies).toHaveLength(2);
+        expect(replies[0]).toBe(SKIN_RAW_IMAGE_LOADING_MSG);
+        expect(replies[1]).toContain('[CQ:image,file=http://localhost:3000/out/');
+        expect(replies[1]).toContain('No.2 测试皮肤(皮肤ID:0)');
+
+        // Image was actually downloaded and landed under out/ (atomic write:
+        // writeFile 落临时文件, rename 落地最终缓存)。
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(writeFile).toHaveBeenCalledTimes(1);
+        expect(rename).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves the cached image without loading hint or download on cache hit', async () => {
+        seedSkinData();
+        // 缓存命中: access 解析即视为文件已存在。
+        vi.mocked(access).mockResolvedValue(undefined);
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { ctx, replies } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        // 单条回复: 本地图片 + 尾注, 无"加载中", 不访问远端。
+        expect(replies).toHaveLength(1);
+        expect(replies[0]).toContain(
+            '[CQ:image,file=http://localhost:3000/out/skin_cache/',
+        );
+        expect(replies[0]).toContain('No.2 测试皮肤(皮肤ID:0)');
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('writes the cache to a content-addressed path (no user/group id)', async () => {
+        seedSkinData();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+                    status: 200,
+                }),
+            ),
+        );
+
+        const { ctx } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        // writeAtomic 先写临时文件: 路径应位于 skin_cache 下、按 weaponId_skinId_hash 寻址,
+        // 且不再使用旧的 tdoll_skin_raw 用户作用域命名。
+        expect(writeFile).toHaveBeenCalledTimes(1);
+        const target = vi.mocked(writeFile).mock.calls[0][0] as string;
+        expect(target).toContain('skin_cache');
+        expect(target).toMatch(/[\\/]2_0_[0-9a-f]{8}\.png/);
+        expect(target).not.toContain('tdoll_skin_raw');
+    });
+
+    it('replies with the timeout message when the download times out', async () => {
+        seedSkinData();
+        const abortErr = new DOMException('signal timed out', 'TimeoutError');
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr));
+
+        const { ctx, replies } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        expect(replies).toHaveLength(2);
+        expect(replies[0]).toBe(SKIN_RAW_IMAGE_LOADING_MSG);
+        expect(replies[1]).toContain(SKIN_RAW_IMAGE_TIMEOUT_MSG);
+        expect(replies[1]).toContain('原链接: https://www.gfwiki.org');
+        // Timed out — must not have written any file.
+        expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('replies with the timeout message on a non-ok HTTP status', async () => {
+        seedSkinData();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(new Response(null, { status: 502 })),
+        );
+
+        const { ctx, replies } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        expect(replies).toHaveLength(2);
+        expect(replies[0]).toBe(SKIN_RAW_IMAGE_LOADING_MSG);
+        expect(replies[1]).toContain(SKIN_RAW_IMAGE_TIMEOUT_MSG);
+        expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('does not cache a 2xx non-image body and falls back to the timeout message', async () => {
+        seedSkinData();
+        // gfwiki 软错误页/CDN 拦截页: HTTP 200 但 body 是 HTML, 非 PNG。
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response('<html><body>error</body></html>', {
+                    status: 200,
+                    headers: { 'content-type': 'text/html' },
+                }),
+            ),
+        );
+
+        const { ctx, replies } = buildCtx(['2', '0']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        // 非 PNG 响应不得写入缓存, 回退为超时提示 + 原链接。
+        expect(replies).toHaveLength(2);
+        expect(replies[0]).toBe(SKIN_RAW_IMAGE_LOADING_MSG);
+        expect(replies[1]).toContain(SKIN_RAW_IMAGE_TIMEOUT_MSG);
+        expect(replies[1]).toContain('原链接: https://www.gfwiki.org');
+        expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('reports missing skin id before attempting any download', async () => {
+        seedSkinData();
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { ctx, replies } = buildCtx(['2', '999']);
+        await TDollSkinCommandRegister.exec(ctx);
+
+        // No loading hint, no fetch — validation message only.
+        expect(replies).toHaveLength(1);
+        expect(replies[0]).toContain('未找到武器 2 下皮肤ID为 999');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/commands/tdoll/register.ts
+++ b/src/commands/tdoll/register.ts
@@ -1,13 +1,73 @@
-import { GlobalEnv, IRegister } from '../../types';
+import { GlobalEnv, IRegister, MsgExecCtx } from '../../types';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { TDollSvc } from './services/tdoll.service';
 import { TDollSkinSvc } from './services/tdollskin.service';
 import { logger } from '../../utils/logger';
-import { TDOLL_SKIN_NOT_FOUND_MSG } from './types/constants';
+import {
+    SKIN_RAW_IMAGE_LOADING_MSG,
+    SKIN_RAW_IMAGE_TIMEOUT_MS,
+    SKIN_RAW_IMAGE_TIMEOUT_MSG,
+    TDOLL_SKIN_NOT_FOUND_MSG,
+} from './types/constants';
 import { buildUserScopedPngName } from '../../utils/cmdreq';
-import { cqImageFile, cqImageUrl } from '../../utils/cqCode';
+import { cqImageFile } from '../../utils/cqCode';
 import { CommandHelper } from './utils/commandHelper';
 import { printTDollDetailPng } from './utils/utils';
 import { resolveSkinImageUrl } from './canvas/assets';
+
+/** out/ 输出目录名(与 baseCanvas 的 OUTPUT_FOLDER 保持一致)。 */
+const OUTPUT_FOLDER = 'out';
+/** 皮肤原图缓存子目录(顶层 out/ 清理会跳过子目录, 故此处长效保留)。 */
+const SKIN_CACHE_SUBDIR = 'skin_cache';
+
+const pathExists = async (p: string): Promise<boolean> => {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * 原子写入: 先落临时文件再 rename, 避免并发请求读到写一半的缓存文件。
+ * 同目录同卷 rename 在 Linux/Windows 上均为原子操作。
+ */
+const writeAtomic = async (target: string, buf: Buffer): Promise<void> => {
+    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+    try {
+        await fs.writeFile(tmp, buf);
+        await fs.rename(tmp, target);
+    } catch (error) {
+        await fs.unlink(tmp).catch(() => {});
+        throw error;
+    }
+};
+
+/**
+ * 生成皮肤原图的内容寻址缓存路径(out/ 相对, 用正斜杠以便拼入 HTTP URL)。
+ *
+ * 原图内容由 (weaponId, skinId) 唯一决定, 与请求用户无关, 故不再带 QQ 号;
+ * 同一张皮肤全局只缓存一份。附加 url 短 hash 用于失效: gfwiki 若更换图片,
+ * 地址变化会落到新文件名, 自动重新下载。
+ */
+const buildSkinCacheRelPath = (
+    weaponId: string,
+    skinId: string,
+    url: string,
+): string => {
+    const urlHash = crypto
+        .createHash('sha1')
+        .update(url)
+        .digest('hex')
+        .slice(0, 8);
+    return path.posix.join(
+        SKIN_CACHE_SUBDIR,
+        `${weaponId}_${skinId}_${urlHash}.png`,
+    );
+};
 
 /**
  * 注入两个数据源的文件路径。环境变量名(TDOLL_DATA_FILE / TDOLL_SKIN_DATA_FILE)
@@ -92,10 +152,17 @@ const createTDollSkinCommand = (name: string, alias: string): IRegister => {
     };
 
     /**
-     * 指定皮肤原图(武器编号 + 皮肤ID)。直接发远端 gfwiki 原图,不落地 out/、不走 canvas。
+     * 指定皮肤原图(武器编号 + 皮肤ID)。
+     *
+     * 原图内容由 (weaponId, skinId) 唯一决定, 与用户无关, 因此按内容寻址
+     * 缓存到 out/skin_cache/(见 {@link buildSkinCacheRelPath}), 全局只存一份:
+     * - 命中缓存: 直接以本地图片回发, 不发"加载中"、不访问远端;
+     * - 未命中: 先发"加载中", 下载远端 gfwiki 原图并原子写入缓存, 再回发。
+     * 这样 go-cqhttp 直接从本地拉取、无二次下载等待; 下载超过
+     * {@link SKIN_RAW_IMAGE_TIMEOUT_MS} 则改为发送超时提示并附带原链接。
      */
     const execSkinRawImage = async (
-        ctx: any,
+        ctx: MsgExecCtx,
         weaponId: string,
         skinId: string
     ) => {
@@ -128,7 +195,63 @@ const createTDollSkinCommand = (name: string, alias: string): IRegister => {
         const url = resolveSkinImageUrl(pic);
         const tail = `No.${weaponId} ${skin.title}(皮肤ID:${skin.value}) | 全部皮肤: #${alias} ${weaponId}`;
 
-        await ctx.reply(`${cqImageUrl(url)}\n${tail}`);
+        // 内容寻址缓存: 命中即直接回图, 跳过"加载中"提示与远端下载。
+        const cacheRelPath = buildSkinCacheRelPath(weaponId, skinId, url);
+        const cacheAbsPath = path.join(
+            process.cwd(),
+            OUTPUT_FOLDER,
+            cacheRelPath,
+        );
+
+        if (await pathExists(cacheAbsPath)) {
+            await ctx.reply(`${cqImageFile(ctx.env, cacheRelPath)}\n${tail}`);
+            return;
+        }
+
+        await ctx.reply(SKIN_RAW_IMAGE_LOADING_MSG);
+
+        try {
+            const resp = await fetch(url, {
+                signal: AbortSignal.timeout(SKIN_RAW_IMAGE_TIMEOUT_MS),
+            });
+            if (!resp.ok) {
+                throw new Error(`HTTP ${resp.status}`);
+            }
+            const buf = Buffer.from(await resp.arrayBuffer());
+
+            // 仅缓存真正的 PNG: 避免把 gfwiki 软错误页/CDN 拦截页等 2xx 非
+            // 图片响应误存为皮肤原图, 进而长达 30 天地返回错误内容。
+            // 不匹配则抛错, 由下方 catch 回退为超时提示 + 原链接, 不污染缓存。
+            const isPng =
+                buf.length >= 4 &&
+                buf[0] === 0x89 &&
+                buf[1] === 0x50 &&
+                buf[2] === 0x4e &&
+                buf[3] === 0x47;
+            if (!isPng) {
+                throw new Error('non-image response');
+            }
+
+            await fs.mkdir(path.dirname(cacheAbsPath), { recursive: true });
+            await writeAtomic(cacheAbsPath, buf);
+
+            await ctx.reply(`${cqImageFile(ctx.env, cacheRelPath)}\n${tail}`);
+        } catch (error) {
+            const isTimeout =
+                error instanceof Error &&
+                (error.name === 'TimeoutError' ||
+                    error.name === 'AbortError');
+            logger.warn('tdollskin raw image download failed', {
+                url,
+                weaponId,
+                skinId,
+                timedOut: isTimeout,
+                error,
+            });
+            await ctx.reply(
+                `${SKIN_RAW_IMAGE_TIMEOUT_MSG}\n原链接: ${url}`,
+            );
+        }
     };
 
     const exec = async (ctx: any) => {

--- a/src/commands/tdoll/types/constants.ts
+++ b/src/commands/tdoll/types/constants.ts
@@ -25,3 +25,14 @@ export const TDOLL_CATEGORY_CN_MAPPER: Record<string, TDollCategoryEnum> = {
 export const TDOLL_SKIN_NOT_FOUND_MSG =
     '未找到指定人形编号的皮肤, 请检查输入是否有误, 请注意需要输入编号而非名称!\n若确认输入编号无误, 多数是 gfwiki 数据问题, 请尝试去 gfwiki 查看数据(这并不是 bot 本身问题)';
 
+/**
+ * 双参数(武器编号 + 皮肤ID)查询皮肤原图时的下载超时与提示文案。
+ *
+ * bot 端先发"加载中"提示, 再用 fetch 把远端 gfwiki 原图下载到 out/ 并以本地
+ * 图片回发(与单参数网格图一致), 下载超过该阈值则改为发送超时提示。
+ */
+export const SKIN_RAW_IMAGE_TIMEOUT_MS = 15_000;
+export const SKIN_RAW_IMAGE_LOADING_MSG = '正在加载皮肤原图, 请稍候...';
+export const SKIN_RAW_IMAGE_TIMEOUT_MSG =
+    '皮肤原图加载超时或失败, 请稍后重试';
+

--- a/src/services/outputCleanup.service.ts
+++ b/src/services/outputCleanup.service.ts
@@ -5,13 +5,18 @@ import { logger } from '../utils/logger';
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
+/** 皮肤原图缓存子目录名(与 tdoll 命令写入路径保持一致)。 */
+const SKIN_CACHE_SUBDIR = 'skin_cache';
+/** 皮肤原图缓存 TTL: 远比顶层产物长, 保留长效命中。 */
+const SKIN_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
 /**
- * 清理输出目录中过期的 PNG 产物。
- * 只处理 dir 顶层的 .png 文件, 子目录(如 out/image-regression)不受影响。
+ * 扫描指定目录下过期的顶层 PNG 并删除。仅处理该目录直接的 .png 文件,
+ * 不递归子目录。
  */
-export const cleanOutputDirOnce = async (
-    dir: string = path.join(process.cwd(), 'out'),
-    ttlMs: number = DEFAULT_TTL_MS,
+const cleanPngDir = async (
+    dir: string,
+    ttlMs: number,
 ): Promise<{ scanned: number; deleted: number }> => {
     const result = { scanned: 0, deleted: 0 };
 
@@ -50,10 +55,29 @@ export const cleanOutputDirOnce = async (
     return result;
 };
 
+/**
+ * 清理输出目录中过期的 PNG 产物。
+ * 只处理 dir 顶层的 .png 文件, 子目录(如 out/image-regression)不受影响。
+ */
+export const cleanOutputDirOnce = async (
+    dir: string = path.join(process.cwd(), 'out'),
+    ttlMs: number = DEFAULT_TTL_MS,
+): Promise<{ scanned: number; deleted: number }> => cleanPngDir(dir, ttlMs);
+
+/**
+ * 清理皮肤原图缓存子目录(out/skin_cache)中过期的 PNG。
+ * 顶层清理会跳过子目录, 故单独按更长 TTL 处理, 避免缓存无限增长。
+ */
+export const cleanSkinCacheOnce = async (
+    dir: string = path.join(process.cwd(), 'out', SKIN_CACHE_SUBDIR),
+    ttlMs: number = SKIN_CACHE_TTL_MS,
+): Promise<{ scanned: number; deleted: number }> => cleanPngDir(dir, ttlMs);
+
 let cleanupTimer: NodeJS.Timeout | null = null;
 
 /**
  * 启动输出目录定时清理: 启动时立即执行一次, 之后每 6 小时执行一次。
+ * 同时按 30 天 TTL 清理皮肤原图缓存子目录。
  */
 export const startOutputCleanupTask = (): void => {
     if (cleanupTimer) {
@@ -62,9 +86,10 @@ export const startOutputCleanupTask = (): void => {
 
     const run = async () => {
         try {
-            const { scanned, deleted } = await cleanOutputDirOnce();
+            const out = await cleanOutputDirOnce();
+            const skin = await cleanSkinCacheOnce();
             logger.info(
-                `[outputCleanup] scanned=${scanned}, deleted=${deleted}`,
+                `[outputCleanup] out scanned=${out.scanned}, deleted=${out.deleted}; skinCache scanned=${skin.scanned}, deleted=${skin.deleted}`,
             );
         } catch (error) {
             logger.error('[outputCleanup] cleanup task failed', error);


### PR DESCRIPTION
Replace per-user output filenames + direct remote-URL reply for the `tdollskin <id> <skinId>` raw-image command with a content-addressed on-disk cache under out/skin_cache/, keyed by (weaponId, skinId, sha1(url)[:8]). The raw image is identical for a given (weaponId, skinId) regardless of who asks, so the QQ/group-scoped filename is no longer needed.

- Cache hit returns the local image instantly: no "loading" hint and no remote fetch.
- Cache miss shows the loading hint, downloads with a 15s timeout, and writes the PNG atomically (temp file + rename) to avoid concurrent readers seeing a half-written file.
- Validate PNG magic bytes before caching so a transient upstream 2xx non-image response (soft-error page / CDN interstitial) can't be persisted and served to all users; non-image bodies fall back to the existing timeout message + original link without writing the cache.
- Extend outputCleanup with cleanSkinCacheOnce (30-day TTL) for out/skin_cache/, since the top-level out/ scan (24h) deliberately skips subdirectories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skin raw images are now downloaded and served from a local cache for faster repeat access.
  * Images are validated before caching, with failed or invalid downloads falling back to the original source link.
  * Users receive loading and timeout messages during image retrieval.

* **Bug Fixes**
  * Prevented invalid image responses from being saved as cached images.
  * Added automatic cleanup of expired cached skin images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->